### PR TITLE
Promoting the shader-internal RNG state to a global variable.

### DIFF
--- a/Intern/rayx-core/src/Tracer/shader/behave.comp
+++ b/Intern/rayx-core/src/Tracer/shader/behave.comp
@@ -8,7 +8,7 @@
 /// - change the rays stokes vector
 /// - potentially absorb the ray (by calling `recordFinalEvent(_, ETYPE_ABSORBED)`)
 
-Ray behaveSlit(Ray r, int id, RAYX_INOUT(uint64_t) ctr, ALLOW_UNUSED Collision col) {
+Ray behaveSlit(Ray r, int id, ALLOW_UNUSED Collision col) {
     SlitBehaviour b = deserializeSlit(elements[id].m_behaviour);
 
     // slit lies in x-y plane instead of x-z plane as other elements
@@ -35,11 +35,11 @@ Ray behaveSlit(Ray r, int id, RAYX_INOUT(uint64_t) ctr, ALLOW_UNUSED Collision c
     if (wavelength > 0) {
         if (openingCutout.m_type == CTYPE_RECT) {
             RectCutout r = deserializeRect(openingCutout);
-            fraun_diff(r.m_width, wavelength, dPhi, ctr);
-            fraun_diff(r.m_length, wavelength, dPsi, ctr);
+            fraun_diff(r.m_width, wavelength, dPhi);
+            fraun_diff(r.m_length, wavelength, dPsi);
         } else if (openingCutout.m_type == CTYPE_ELLIPTICAL) {
             EllipticalCutout e = deserializeElliptical(openingCutout);
-            bessel_diff(e.m_diameter_z, wavelength, dPhi, dPsi, ctr);
+            bessel_diff(e.m_diameter_z, wavelength, dPhi, dPsi);
         } else {
             throw("encountered Slit with unsupported openingCutout");
         }
@@ -54,7 +54,7 @@ Ray behaveSlit(Ray r, int id, RAYX_INOUT(uint64_t) ctr, ALLOW_UNUSED Collision c
     return r;
 }
 
-Ray behaveRZP(Ray r, int id, RAYX_INOUT(uint64_t) ctr, Collision col) {
+Ray behaveRZP(Ray r, int id, Collision col) {
     RZPBehaviour b = deserializeRZP(elements[id].m_behaviour);
 
     double WL            = hvlam(r.m_energy);
@@ -80,7 +80,7 @@ Ray behaveRZP(Ray r, int id, RAYX_INOUT(uint64_t) ctr, Collision col) {
     return r;
 }
 
-Ray behaveGrating(Ray r, int id, ALLOW_UNUSED RAYX_INOUT(uint64_t) ctr, Collision col) {
+Ray behaveGrating(Ray r, int id, Collision col) {
     GratingBehaviour b = deserializeGrating(elements[id].m_behaviour);
 
     // vls parameters passed in q.elementParams
@@ -99,7 +99,7 @@ Ray behaveGrating(Ray r, int id, ALLOW_UNUSED RAYX_INOUT(uint64_t) ctr, Collisio
     return r;
 }
 
-Ray behaveMirror(Ray r, int id, RAYX_INOUT(uint64_t) ctr, Collision col) {
+Ray behaveMirror(Ray r, int id, Collision col) {
     // calculate intersection point and normal at intersection point
     double azimuthal_angle = elements[id].m_azimuthalAngle;
 
@@ -112,7 +112,7 @@ Ray behaveMirror(Ray r, int id, RAYX_INOUT(uint64_t) ctr, Collision col) {
     if (mat != -2) {
         efficiency(r, real_S, real_P, delta, incidence_angle, mat);
 
-        bool absorbed = update_stokes(r, real_S, real_P, delta, azimuthal_angle, ctr);
+        bool absorbed = update_stokes(r, real_S, real_P, delta, azimuthal_angle);
         if (absorbed) {
             recordFinalEvent(r, ETYPE_ABSORBED);
         }

--- a/Intern/rayx-core/src/Tracer/shader/collision.comp
+++ b/Intern/rayx-core/src/Tracer/shader/collision.comp
@@ -241,7 +241,7 @@ Collision RAYX_API findCollisionInElementCoords(Ray r, Surface surface, Cutout c
 
 // checks whether `r` collides with the element of the given `id`,
 // and returns a Collision accordingly.
-Collision findCollisionWith(Ray r, uint id, RAYX_INOUT(uint64_t) ctr) {
+Collision findCollisionWith(Ray r, uint id) {
     // misalignment
     r = rayMatrixMult(r, elements[id].m_inTrans);  // image plane is the x-y plane of the coordinate system
     Collision col = findCollisionInElementCoords(r, elements[id].m_surface, elements[id].m_cutout, false);
@@ -250,20 +250,20 @@ Collision findCollisionWith(Ray r, uint id, RAYX_INOUT(uint64_t) ctr) {
     }
 
     SlopeError sE = elements[id].m_slopeError;
-    col.normal = applySlopeError(col.normal, sE, 0, ctr);
+    col.normal = applySlopeError(col.normal, sE, 0);
 
     return col;
 }
 
 // Returns the next collision for the ray `_ray`.
-Collision findCollision(RAYX_INOUT(uint64_t) ctr) {
+Collision findCollision() {
     if (pushConstants.sequential == 1.0) {
         if (_ray.m_lastElement >= elements.length() - 1) {
             Collision col;
             col.found = false;
             return col;
         }
-        return findCollisionWith(_ray, uint(_ray.m_lastElement + 1), ctr);
+        return findCollisionWith(_ray, uint(_ray.m_lastElement + 1));
     }
 
     // global coordinates of first intersection point of ray among all elements in beamline
@@ -281,7 +281,7 @@ Collision findCollision(RAYX_INOUT(uint64_t) ctr) {
 
     // Find intersection points through all elements
     for (uint elementIndex = 0; elementIndex < uint(elements.length()); elementIndex++) {
-        Collision current_col = findCollisionWith(r, elementIndex, ctr);
+        Collision current_col = findCollisionWith(r, elementIndex);
         if (!current_col.found) {
             continue;
         }

--- a/Intern/rayx-core/src/Tracer/shader/dynamic_elements.comp
+++ b/Intern/rayx-core/src/Tracer/shader/dynamic_elements.comp
@@ -5,11 +5,6 @@ void dynamicElements() {
     // placeholder, info should later be transfered to shader
     const int maxBounces = elements.length();
 
-    // ray specific "seed" for random numbers -> every ray has a different starting value for the counter that creates the random number
-    const uint64_t MAX_UINT64 = ~(uint64_t(0));
-    uint64_t workerCounterNum = MAX_UINT64 / uint64_t(pushConstants.numRays);
-    uint64_t ctr              = rayId() * workerCounterNum + uint64_t(pushConstants.randomSeed * MAX_UINT64);
-
     #ifdef RAYX_DEBUG_MODE // Debug Matrix only works in GPU Mode and on DEBUG Build Type
     #ifdef GLSL
         // Set Debug Struct of current Ray to identity
@@ -24,7 +19,7 @@ void dynamicElements() {
 
     // Iterate through all bounces
     for (int i = 0; i < maxBounces; i++) {
-        Collision col = findCollision(ctr);
+        Collision col = findCollision();
         if (!col.found) {
             // no element was hit.
             // Ray is considered to move forward to inf.
@@ -46,16 +41,16 @@ void dynamicElements() {
 
         switch(btype) {
             case (BTYPE_MIRROR):
-                elem_ray = behaveMirror(elem_ray, col.elementIndex, ctr, col);
+                elem_ray = behaveMirror(elem_ray, col.elementIndex, col);
                 break;
             case (BTYPE_GRATING):
-                elem_ray = behaveGrating(elem_ray, col.elementIndex, ctr, col);
+                elem_ray = behaveGrating(elem_ray, col.elementIndex, col);
                 break;
             case (BTYPE_SLIT) :
-                elem_ray = behaveSlit(elem_ray, col.elementIndex, ctr, col);
+                elem_ray = behaveSlit(elem_ray, col.elementIndex, col);
                 break;
             case (BTYPE_RZP):
-                elem_ray = behaveRZP(elem_ray, col.elementIndex, ctr, col);
+                elem_ray = behaveRZP(elem_ray, col.elementIndex, col);
                 break;
             case (BTYPE_IMAGE_PLANE):
                 elem_ray = behaveImagePlane(elem_ray, col.elementIndex, col);
@@ -71,7 +66,7 @@ void dynamicElements() {
         _ray = rayMatrixMult(elem_ray, nextElement.m_outTrans);
     }
 
-    if (findCollision(ctr).found) {
+    if (findCollision().found) {
         recordFinalEvent(_ray, ETYPE_NOT_ENOUGH_BOUNCES);
     } else {
         recordFinalEvent(_ray, ETYPE_FLY_OFF);

--- a/Intern/rayx-core/src/Tracer/shader/main.comp
+++ b/Intern/rayx-core/src/Tracer/shader/main.comp
@@ -83,6 +83,9 @@ uint64_t rayId() {
 
 bool finalized;
 
+// the random number state.
+uint64_t ctr;
+
 // `i in [0, maxEvents]`.
 // Will return the index in outputData to access the `i'th` output ray belonging to this shader call.
 // Typically used as `outputData[output_index(i)]`.
@@ -159,6 +162,11 @@ void recordFinalEvent(Ray r, double w) {
 void main() {
     finalized = false;
     uninitOutRays();
+
+    // ray specific "seed" for random numbers -> every ray has a different starting value for the counter that creates the random number
+    const uint64_t MAX_UINT64 = ~(uint64_t(0));
+    uint64_t workerCounterNum = MAX_UINT64 / uint64_t(pushConstants.numRays);
+    ctr = rayId() * workerCounterNum + uint64_t(pushConstants.randomSeed * MAX_UINT64);
     
     // ~~~~~~~~~~~~~~ PRINT EXAMPLE ~~~~~~~~~~~~~~
     // Printing ~DEBUG~ Example over vkconfig Validation Layers

--- a/Intern/rayx-core/src/Tracer/shader/random.comp
+++ b/Intern/rayx-core/src/Tracer/shader/random.comp
@@ -8,11 +8,12 @@ const uint64_t rngKey = (uint64_t(0xc8e4fd15) << 32) | uint64_t(0x4ce32f6d);
  * URL: https://arxiv.org/pdf/2004.06278.pdf
  */
 // generates 64-Bit random integers
-uint64_t RAYX_API squares64(RAYX_INOUT(uint64_t) ctr) {
+// we use `ctr_` here to distinguish it from the global `ctr`.
+uint64_t RAYX_API squares64(RAYX_INOUT(uint64_t) ctr_) {
     uint64_t x, y, z, t;
-    y = x = ctr * rngKey;
+    y = x = ctr_ * rngKey;
     z = y + rngKey;
-    ctr++;
+    ctr_++;
 
     x = x * x + y;
     x = (x >> 32) | (x << 32); /* round 1 */
@@ -27,21 +28,21 @@ uint64_t RAYX_API squares64(RAYX_INOUT(uint64_t) ctr) {
 
 // generates uniformly distributed doubles between 0 and 1 from one 64-Bit
 // random integer
-double RAYX_API squaresDoubleRNG(RAYX_INOUT(uint64_t) ctr) {
-    double a = double(squares64(ctr));
+double RAYX_API squaresDoubleRNG(RAYX_INOUT(uint64_t) ctr_) {
+    double a = double(squares64(ctr_));
     double div = double(uint64_t(0) - 1);
     return a / div;
 }
 
 // creates (via the Box-Muller transform) a normal distributed double with mean
 // mu and standard deviation sigma
-double RAYX_API squaresNormalRNG(RAYX_INOUT(uint64_t) ctr, double mu, double sigma) {
+double RAYX_API squaresNormalRNG(RAYX_INOUT(uint64_t) ctr_, double mu, double sigma) {
     double U, V, R, Z;
     double two_pi = 2.0 * PI;
 
-    U = squaresDoubleRNG(ctr);
-    V = squaresDoubleRNG(ctr);
-    R = squaresDoubleRNG(ctr);
+    U = squaresDoubleRNG(ctr_);
+    V = squaresDoubleRNG(ctr_);
+    R = squaresDoubleRNG(ctr_);
     Z = sqrt(-2.0 * r8_log(U));
 
     if (R < 0.5)

--- a/Intern/rayx-core/src/Tracer/shader/utils.comp
+++ b/Intern/rayx-core/src/Tracer/shader/utils.comp
@@ -460,7 +460,7 @@ dmat4 muller_matrix(double R_s, double R_p, double delta) {
  * updates stokes vector of ray
  * @returns `true`, if ray should be absorbed
  */
-bool update_stokes(RAYX_INOUT(Ray) r, double real_S, double real_P, double delta, double azimuthal, RAYX_INOUT(uint64_t) ctr) {
+bool update_stokes(RAYX_INOUT(Ray) r, double real_S, double real_P, double delta, double azimuthal) {
     dvec4 stokes_old = r.m_stokes;
     double c_chi = r8_cos(azimuthal);
     double s_chi = r8_sin(azimuthal);
@@ -531,7 +531,7 @@ adds slope error to the normal
 1=cylindrical) (1 only for ellipsis relevant) returns new normal if there is a
 slope error in either x or z direction or the unmodified normal otherwise.
 */
-dvec3 applySlopeError(dvec3 normal, SlopeError error, int O_type, RAYX_INOUT(uint64_t) ctr) {
+dvec3 applySlopeError(dvec3 normal, SlopeError error, int O_type) {
     double slopeX = error.m_sag;
     double slopeZ = error.m_mer;
 
@@ -861,7 +861,7 @@ zoneplates
 @returns
     results stored in dphi, dpsi (inout)
 */
-void bessel_diff(double radius, double wl, RAYX_INOUT(double) dphi, RAYX_INOUT(double) dpsi, RAYX_INOUT(uint64_t) ctr) {
+void bessel_diff(double radius, double wl, RAYX_INOUT(double) dphi, RAYX_INOUT(double) dpsi) {
     double b = abs(radius) * 1e06;
     double ximax = 5.0 * wl / b;
 
@@ -894,10 +894,9 @@ void bessel_diff(double radius, double wl, RAYX_INOUT(double) dphi, RAYX_INOUT(d
  * @param dim		dimension (x or y) (mm)
  * @param wl			wavelength (nm)
  * @param dAngle 	diffraction angle (inout)
- * @param ctr		counter for random number generator
  * @return result stored in dAngle
  */
-void fraun_diff(double dim, double wl, RAYX_INOUT(double) dAngle, RAYX_INOUT(uint64_t) ctr) {
+void fraun_diff(double dim, double wl, RAYX_INOUT(double) dAngle) {
     if (dim == 0) return;        // no diffraction in this direction
     double b = dim * 1e06;       // slit opening
     double div = 10.0 * wl / b;  // up to 2nd maximum


### PR DESCRIPTION
Currently, we pass `ctr` through the whole codebase of the shader.
Making it a global allows us to remove quite a bit of pass-through code.

I'd like your feedback on this though, as this would add global mutable state - which I think shouldn't be used excessively.

Thoughts?
