### PR TITLE
Ray filtering + lookAtPoint

### DIFF
--- a/Intern/rayx-ui/src/Application.cpp
+++ b/Intern/rayx-ui/src/Application.cpp
@@ -79,7 +79,7 @@ void Application::run() {
 
     // CLI Input
     std::string rmlPathCli = m_CommandParser.m_args.m_providedFile;
-    UIRayInfo rayInfo{false, 50, 100};
+    UIRayInfo rayInfo{true, false, 50, 100};
     UIParameters uiParams{camController, rmlPathCli, !rmlPathCli.empty(), 0.0, rayInfo};
 
     // Main loop
@@ -102,11 +102,17 @@ void Application::run() {
             if (uiParams.pathChanged) {
                 updateObjects(uiParams.rmlPath.string(), rObjects);
                 loadRays(uiParams.rmlPath.string(), rayCache, uiParams.rayInfo);
-                updateRays(uiParams.rmlPath.string(), rayCache, rayObj, rays, uiParams.rayInfo);
+                if (uiParams.rayInfo.displayRays) {
+                    updateRays(uiParams.rmlPath.string(), rayCache, rayObj, rays, uiParams.rayInfo);
+                }
                 uiParams.pathChanged = false;
                 camController.lookAtPoint(rObjects[0].getTranslationVecor());
             } else if (uiParams.rayInfo.raysChanged) {
-                updateRays(uiParams.rmlPath.string(), rayCache, rayObj, rays, uiParams.rayInfo);
+                if (uiParams.rayInfo.displayRays) {
+                    updateRays(uiParams.rmlPath.string(), rayCache, rayObj, rays, uiParams.rayInfo);
+                } else {
+                    rayObj.reset();
+                }
                 uiParams.rayInfo.raysChanged = false;
             }
 

--- a/Intern/rayx-ui/src/Application.cpp
+++ b/Intern/rayx-ui/src/Application.cpp
@@ -65,6 +65,7 @@ void Application::run() {
     // Camera
     CameraController camController;
     Camera cam;
+    int amountOfRays = 10;
 
     // Input callbacks
     glfwSetKeyCallback(m_Window.window(), keyCallback);
@@ -79,7 +80,7 @@ void Application::run() {
 
     // CLI Input
     std::string rmlPathCli = m_CommandParser.m_args.m_providedFile;
-    UIParameters uiParams{camController, rmlPathCli, !rmlPathCli.empty(), 0.0};
+    UIParameters uiParams{camController, rmlPathCli, !rmlPathCli.empty(), false, 0.0, amountOfRays};
 
     // Main loop
     while (!m_Window.shouldClose()) {
@@ -99,9 +100,13 @@ void Application::run() {
             uiRenderSystem.setupUI(uiParams, rObjects);
             // camController.update(cam, m_Renderer.getAspectRatio());
             if (uiParams.pathChanged) {
-                updateScene(uiParams.rmlPath.string(), rObjects, rays, rayObj);
+                updateObjects(uiParams.rmlPath.string(), rObjects);
+                updateRays(uiParams.rmlPath.string(), rayObj, rays, uiParams.amountOfRays);
                 uiParams.pathChanged = false;
                 camController.lookAtPoint(rObjects[0].getTranslationVecor());
+            } else if (uiParams.raysChanged) {
+                updateRays(uiParams.rmlPath.string(), rayObj, rays, uiParams.amountOfRays);
+                uiParams.raysChanged = false;
             }
 
             camController.update(cam, m_Renderer.getAspectRatio());
@@ -130,61 +135,14 @@ void Application::run() {
     vkDeviceWaitIdle(m_Device.device());
 }
 
-/**
- * This function processes the BundleHistory and determines the ray's path in the beamline.
- * Depending on the event type associated with the ray, the function produces visual lines that represent
- * ray segments, colored based on the event type.
- */
-std::vector<Line> getRays(const RAYX::BundleHistory& bundleHist, const std::vector<RAYX::OpticalElement>& elements) {
-    std::vector<Line> rays;
-
-    for (const RAYX::RayHistory& rayHist : bundleHist) {
-        glm::vec3 rayLastPos = {0.0f, 0.0f, 0.0f};
-        for (const RAYX::Event& event : rayHist) {
-            if (event.m_eventType == ETYPE_JUST_HIT_ELEM || event.m_eventType == ETYPE_ABSORBED) {
-                // Events where rays hit objects are in element coordinates
-                // We need to convert them to world coordinates
-                glm::vec4 worldPos = elements[(size_t)event.m_lastElement].m_element.m_outTrans * glm::vec4(event.m_position, 1.0f);
-
-                Vertex origin = {{rayLastPos.x, rayLastPos.y, rayLastPos.z, 1.0f}, YELLOW};
-                Vertex point = (event.m_eventType == ETYPE_JUST_HIT_ELEM) ? Vertex(worldPos, ORANGE) : Vertex(worldPos, RED);
-
-                Line myline = {origin, point};
-                rays.push_back(myline);
-                rayLastPos = point.pos;
-            } else if (event.m_eventType == ETYPE_FLY_OFF) {
-                // Fly off events are in world coordinates
-                // The origin here is the position of the event
-                // The point is defined by the direction of the ray (default length)
-
-                glm::vec4 eventPos = glm::vec4(event.m_position, 1.0f);
-                glm::vec4 eventDir = glm::vec4(event.m_direction, 0.0f);
-                glm::vec4 pointPos = eventPos + eventDir * 1000.0f;
-
-                Vertex origin = {eventPos, GREY};
-                Vertex point = {pointPos, GREY};
-
-                rays.push_back(Line(origin, point));
-            } else if (event.m_eventType == ETYPE_NOT_ENOUGH_BOUNCES) {
-                // Events where rays hit objects are in element coordinates
-                // We need to convert them to world coordinates
-                glm::vec4 worldPos = elements[(size_t)event.m_lastElement].m_element.m_outTrans * glm::vec4(event.m_position, 1.0f);
-
-                const glm::vec4 white = {1.0f, 1.0f, 1.0f, 0.7f};
-                Vertex origin = {{rayLastPos.x, rayLastPos.y, rayLastPos.z, 1.0f}, white};
-                Vertex point = Vertex(worldPos, white);
-
-                rays.push_back(Line(origin, point));
-                rayLastPos = point.pos;
-            }
-        }
-    }
-
-    return rays;
+void Application::updateObjects(const std::string& path, std::vector<RenderObject>& rObjects) {
+    RAYX::Beamline beamline = RAYX::importBeamline(path);
+    // TODO(Jannis): Hacky fix for now; should be some form of synchronization
+    vkDeviceWaitIdle(m_Device.device());
+    // Triangulate the render data and update the scene
+    rObjects = triangulateObjects(beamline.m_OpticalElements, m_Device);
 }
-
-void Application::updateScene(const std::string& path, std::vector<RenderObject>& rObjects, std::vector<Line>& rays,
-                              std::optional<RenderObject>& rayObj) {
+void Application::updateRays(const std::string& path, std::optional<RenderObject>& rayObj, std::vector<Line>& rays, int amountOfRays) {
     RAYX::Beamline beamline = RAYX::importBeamline(path);
 #ifndef NO_H5
     std::string rayFilePath = path.substr(0, path.size() - 4) + ".h5";
@@ -193,12 +151,9 @@ void Application::updateScene(const std::string& path, std::vector<RenderObject>
     std::string rayFilePath = path.substr(0, path.size() - 4) + ".csv";
     RAYX::BundleHistory bundleHist = loadCSV(rayFilePath);
 #endif
-    vkDeviceWaitIdle(m_Device.device());  // TODO(Jannis): Hacky fix for now; should be some form of synchronization
-
-    // Triangulate the render data and update the scene
-    rObjects = triangulateObjects(beamline.m_OpticalElements, m_Device);
-    rays = getRays(bundleHist, beamline.m_OpticalElements, kMeansFilter);
-
+    // TODO(Jannis): Hacky fix for now; should be some form of synchronization
+    vkDeviceWaitIdle(m_Device.device());
+    rays = getRays(bundleHist, beamline.m_OpticalElements, kMeansFilter, amountOfRays);
     if (!rays.empty()) {
         // Temporarily aggregate all vertices, then create a single RenderObject
         std::vector<Vertex> rayVertices(rays.size() * 2);

--- a/Intern/rayx-ui/src/Application.cpp
+++ b/Intern/rayx-ui/src/Application.cpp
@@ -78,7 +78,7 @@ void Application::run() {
 
     // CLI Input
     std::string rmlPathCli = m_CommandParser.m_args.m_providedFile;
-    UIRayInfo rayInfo{false, 10, 100};
+    UIRayInfo rayInfo{false, 50, 100};
     UIParameters uiParams{camController, rmlPathCli, !rmlPathCli.empty(), 0.0, rayInfo};
 
     // Main loop

--- a/Intern/rayx-ui/src/Application.cpp
+++ b/Intern/rayx-ui/src/Application.cpp
@@ -101,13 +101,13 @@ void Application::run() {
             // camController.update(cam, m_Renderer.getAspectRatio());
             if (uiParams.pathChanged) {
                 updateObjects(uiParams.rmlPath.string(), rObjects);
-                loadRays(uiParams.rmlPath.string(), rayCache, uiParams.rayInfo);
-                if (uiParams.rayInfo.displayRays) {
-                    updateRays(uiParams.rmlPath.string(), rayCache, rayObj, rays, uiParams.rayInfo);
-                }
+                createRayCache(uiParams.rmlPath.string(), rayCache, uiParams.rayInfo);
                 uiParams.pathChanged = false;
                 camController.lookAtPoint(rObjects[0].getTranslationVecor());
-            } else if (uiParams.rayInfo.raysChanged) {
+                uiParams.rayInfo.raysChanged = true;
+            }
+
+            if (uiParams.rayInfo.raysChanged) {
                 if (uiParams.rayInfo.displayRays) {
                     updateRays(uiParams.rmlPath.string(), rayCache, rayObj, rays, uiParams.rayInfo);
                 } else {
@@ -149,7 +149,7 @@ void Application::updateObjects(const std::string& path, std::vector<RenderObjec
     // Triangulate the render data and update the scene
     rObjects = triangulateObjects(beamline.m_OpticalElements, m_Device);
 }
-void Application::loadRays(const std::string& path, BundleHistory& rayCache, UIRayInfo& rayInfo) {
+void Application::createRayCache(const std::string& path, BundleHistory& rayCache, UIRayInfo& rayInfo) {
 #ifndef NO_H5
     std::string rayFilePath = path.substr(0, path.size() - 4) + ".h5";
     RAYX::BundleHistory bundleHist = raysFromH5(rayFilePath, FULL_FORMAT);

--- a/Intern/rayx-ui/src/Application.cpp
+++ b/Intern/rayx-ui/src/Application.cpp
@@ -8,6 +8,7 @@
 #include "FrameInfo.h"
 #include "GraphicsCore/Renderer.h"
 #include "GraphicsCore/Window.h"
+#include "RayProcessing.h"
 #include "RenderObject.h"
 #include "RenderSystem/GridRenderSystem.h"
 #include "RenderSystem/ObjectRenderSystem.h"
@@ -196,7 +197,7 @@ void Application::updateScene(const std::string& path, std::vector<RenderObject>
 
     // Triangulate the render data and update the scene
     rObjects = triangulateObjects(beamline.m_OpticalElements, m_Device);
-    rays = getRays(bundleHist, beamline.m_OpticalElements);
+    rays = getRays(bundleHist, beamline.m_OpticalElements, kMeansFilter);
 
     if (!rays.empty()) {
         // Temporarily aggregate all vertices, then create a single RenderObject

--- a/Intern/rayx-ui/src/Application.h
+++ b/Intern/rayx-ui/src/Application.h
@@ -5,6 +5,7 @@
 #include "CommandParser.h"
 #include "GraphicsCore/Descriptors.h"
 #include "GraphicsCore/Renderer.h"
+#include "RayProcessing.h"
 #include "RenderSystem/UIRenderSystem.h"
 // TODO: This is also in Device Class
 const std::vector<const char*> validationLayers = {"VK_LAYER_KHRONOS_validation"};
@@ -48,6 +49,7 @@ class Application {
     std::unique_ptr<DescriptorPool> m_DescriptorPool{nullptr};
 
     void updateObjects(const std::string& path, std::vector<RenderObject>& rObjects);
-
-    void updateRays(const std::string& path, std::optional<RenderObject>& rayObj, std::vector<Line>& rays, UIRayInfo& rayInfo);
+    void loadRays(const std::string& path, BundleHistory& rayCache, UIRayInfo& rayInfo);
+    void updateRays(const std::string& path, BundleHistory& rayCache, std::optional<RenderObject>& rayObj, std::vector<Line>& rays,
+                    UIRayInfo& rayInfo);
 };

--- a/Intern/rayx-ui/src/Application.h
+++ b/Intern/rayx-ui/src/Application.h
@@ -47,5 +47,7 @@ class Application {
 
     std::unique_ptr<DescriptorPool> m_DescriptorPool{nullptr};
 
-    void updateScene(const std::string& path, std::vector<RenderObject>& rObjects, std::vector<Line>& rays, std::optional<RenderObject>& rayObj);
+    void updateObjects(const std::string& path, std::vector<RenderObject>& rObjects);
+
+    void updateRays(const std::string& path, std::optional<RenderObject>& rayObj, std::vector<Line>& rays, int amountOfRays);
 };

--- a/Intern/rayx-ui/src/Application.h
+++ b/Intern/rayx-ui/src/Application.h
@@ -49,7 +49,7 @@ class Application {
     std::unique_ptr<DescriptorPool> m_DescriptorPool{nullptr};
 
     void updateObjects(const std::string& path, std::vector<RenderObject>& rObjects);
-    void loadRays(const std::string& path, BundleHistory& rayCache, UIRayInfo& rayInfo);
+    void createRayCache(const std::string& path, BundleHistory& rayCache, UIRayInfo& rayInfo);
     void updateRays(const std::string& path, BundleHistory& rayCache, std::optional<RenderObject>& rayObj, std::vector<Line>& rays,
                     UIRayInfo& rayInfo);
 };

--- a/Intern/rayx-ui/src/Application.h
+++ b/Intern/rayx-ui/src/Application.h
@@ -5,7 +5,7 @@
 #include "CommandParser.h"
 #include "GraphicsCore/Descriptors.h"
 #include "GraphicsCore/Renderer.h"
-
+#include "RenderSystem/UIRenderSystem.h"
 // TODO: This is also in Device Class
 const std::vector<const char*> validationLayers = {"VK_LAYER_KHRONOS_validation"};
 const std::vector<const char*> deviceExtensions = {VK_KHR_SWAPCHAIN_EXTENSION_NAME};
@@ -49,5 +49,5 @@ class Application {
 
     void updateObjects(const std::string& path, std::vector<RenderObject>& rObjects);
 
-    void updateRays(const std::string& path, std::optional<RenderObject>& rayObj, std::vector<Line>& rays, int amountOfRays);
+    void updateRays(const std::string& path, std::optional<RenderObject>& rayObj, std::vector<Line>& rays, UIRayInfo& rayInfo);
 };

--- a/Intern/rayx-ui/src/Camera.cpp
+++ b/Intern/rayx-ui/src/Camera.cpp
@@ -128,7 +128,7 @@ void CameraController::lookAtPoint(const glm::vec3& targetPoint, float distance)
     float z = targetPoint.z - offset;
 
     // Set the camera's y-coordinate with an offset
-    float y = targetPoint.y + offset;  // You can adjust the Y offset as needed
+    float y = targetPoint.y + offset;
 
     m_position = glm::vec3(x, y, z);
 
@@ -139,7 +139,6 @@ void CameraController::lookAtPoint(const glm::vec3& targetPoint, float distance)
     m_pitch = glm::degrees(std::asin(m_direction.y));
     m_yaw = glm::degrees(std::atan2(m_direction.z, m_direction.x));
 
-    // Update the camera direction without triggering pitch and yaw clamping
     updateDirection(0.0, 0.0);
 }
 

--- a/Intern/rayx-ui/src/Camera.cpp
+++ b/Intern/rayx-ui/src/Camera.cpp
@@ -120,14 +120,24 @@ void CameraController::update(Camera& cam, float aspectRatio) {
 }
 
 void CameraController::lookAtPoint(const glm::vec3& targetPoint, float distance) {
-    glm::vec3 right = glm::normalize(glm::cross(m_direction, m_up));
-    glm::vec3 upOffset = m_up * 10.0f;
-    m_position = targetPoint + (right * distance) + upOffset;
+    // Set the camera's x-coordinate to match the target point
+    float x = targetPoint.x;
 
+    // Calculate the z-coordinate using Pythagoras, ensuring the camera stays at the specified distance
+    float offset = std::sqrt(distance);
+    float z = targetPoint.z - offset;
+
+    // Set the camera's y-coordinate with an offset
+    float y = targetPoint.y + offset;  // You can adjust the Y offset as needed
+
+    m_position = glm::vec3(x, y, z);
+
+    // Update the camera's direction to point towards the target
     m_direction = glm::normalize(targetPoint - m_position);
 
-    m_pitch = glm::degrees(asin(m_direction.y));
-    m_yaw = glm::degrees(atan2(m_direction.z, m_direction.x));
+    // Update the pitch and yaw based on the new direction
+    m_pitch = glm::degrees(std::asin(m_direction.y));
+    m_yaw = glm::degrees(std::atan2(m_direction.z, m_direction.x));
 
     // Update the camera direction without triggering pitch and yaw clamping
     updateDirection(0.0, 0.0);

--- a/Intern/rayx-ui/src/Camera.h
+++ b/Intern/rayx-ui/src/Camera.h
@@ -26,7 +26,7 @@ class CameraController {
     bool isMouseLooking() const;
     void setLastMousePos(float x, float y);
     void updateDirectionViaMouse(float mouseX, float mouseY);
-    void lookAtPoint(const glm::vec3& targetPoint, float distance = 50.0f);
+    void lookAtPoint(const glm::vec3& targetPoint, float distance = 100.0f);
 
     void displaySettings();
     void update(Camera& cam, float aspectRatio);

--- a/Intern/rayx-ui/src/Camera.h
+++ b/Intern/rayx-ui/src/Camera.h
@@ -26,7 +26,7 @@ class CameraController {
     bool isMouseLooking() const;
     void setLastMousePos(float x, float y);
     void updateDirectionViaMouse(float mouseX, float mouseY);
-    void lookAtPoint(const glm::vec3& targetPoint, float distance = 100.0f);
+    void lookAtPoint(const glm::vec3& targetPoint, float distance = 200.0f);
 
     void displaySettings();
     void update(Camera& cam, float aspectRatio);

--- a/Intern/rayx-ui/src/RayProcessing.cpp
+++ b/Intern/rayx-ui/src/RayProcessing.cpp
@@ -1,0 +1,184 @@
+#include "RayProcessing.h"
+
+#include "Colors.h"
+
+/**
+ * This function processes the BundleHistory and determines the ray's path in the beamline.
+ * Depending on the event type associated with the ray, the function produces visual lines that represent
+ * ray segments, colored based on the event type.
+ */
+// Define the type of the filter function
+
+std::vector<Line> getRays(const RAYX::BundleHistory& bundleHist, const std::vector<RAYX::OpticalElement>& elements,
+                          RayFilterFunction filterFunction) {
+    std::vector<Line> rays;
+
+    int k = 3;  // temporary value for k
+    // Apply the filter function to get the indices of the rays to be rendered
+    std::vector<size_t> rayIndices = filterFunction(bundleHist, k);  // k needs to be defined or passed into this function
+    for (size_t i : rayIndices) {
+        auto& rayHist = bundleHist[i];
+        glm::vec3 rayLastPos = {0.0f, 0.0f, 0.0f};
+        for (const auto& event : rayHist) {
+            if (event.m_eventType == ETYPE_JUST_HIT_ELEM || event.m_eventType == ETYPE_ABSORBED) {
+                // Events where rays hit objects are in element coordinates
+                // We need to convert them to world coordinates
+                glm::vec4 worldPos = elements[(size_t)event.m_lastElement].m_element.m_outTrans * glm::vec4(event.m_position, 1.0f);
+
+                Vertex origin = {{rayLastPos.x, rayLastPos.y, rayLastPos.z, 1.0f}, YELLOW};
+                Vertex point = (event.m_eventType == ETYPE_JUST_HIT_ELEM) ? Vertex(worldPos, ORANGE) : Vertex(worldPos, RED);
+
+                Line myline = {origin, point};
+                rays.push_back(myline);
+                rayLastPos = point.pos;
+            } else if (event.m_eventType == ETYPE_FLY_OFF) {
+                // Fly off events are in world coordinates
+                // The origin here is the position of the event
+                // The point is defined by the direction of the ray (default length)
+
+                glm::vec4 eventPos = glm::vec4(event.m_position, 1.0f);
+                glm::vec4 eventDir = glm::vec4(event.m_direction, 0.0f);
+                glm::vec4 pointPos = eventPos + eventDir * 1000.0f;
+
+                Vertex origin = {eventPos, GREY};
+                Vertex point = {pointPos, GREY};
+
+                rays.push_back(Line(origin, point));
+            } else if (event.m_eventType == ETYPE_NOT_ENOUGH_BOUNCES) {
+                // Events where rays hit objects are in element coordinates
+                // We need to convert them to world coordinates
+                glm::vec4 worldPos = elements[(size_t)event.m_lastElement].m_element.m_outTrans * glm::vec4(event.m_position, 1.0f);
+
+                const glm::vec4 white = {1.0f, 1.0f, 1.0f, 0.7f};
+                Vertex origin = {{rayLastPos.x, rayLastPos.y, rayLastPos.z, 1.0f}, white};
+                Vertex point = Vertex(worldPos, white);
+
+                rays.push_back(Line(origin, point));
+                rayLastPos = point.pos;
+            }
+        }
+    }
+
+    return rays;
+}
+
+std::vector<std::vector<float>> extractFeatures(const RAYX::BundleHistory& bundleHist, size_t eventIndex) {
+    std::vector<std::vector<float>> features;
+    for (const auto& rayHist : bundleHist) {
+        if (eventIndex < rayHist.size()) {
+            // Extract features from the ray event, specifically position
+            const auto& event = rayHist[eventIndex];
+            features.push_back({float(event.m_position.x), float(event.m_position.y), float(event.m_position.z)});
+        }
+    }
+    return features;
+}
+
+// Assume this is a function that performs k-means clustering
+std::pair<std::vector<size_t>, std::vector<std::vector<float>>> kMeansClustering(const std::vector<std::vector<float>>& features, size_t k);
+
+// Helper function to find the index of the most central ray in each cluster
+std::vector<size_t> findMostCentralRays(const std::vector<std::vector<float>>& features, const std::vector<size_t>& clusterAssignments,
+                                        const std::vector<std::vector<float>>& centroids, size_t k) {
+    std::vector<size_t> centralRaysIndices(k, std::numeric_limits<size_t>::max());
+    std::vector<float> minDistances(k, std::numeric_limits<float>::max());
+
+    for (size_t i = 0; i < features.size(); ++i) {
+        size_t clusterIdx = clusterAssignments[i];
+        float distance = 0.0f;  // Calculate the distance between features[i] and centroids[clusterIdx]
+        // Distance calculation, could be Euclidean or another metric
+        for (size_t j = 0; j < features[i].size(); ++j) {
+            distance += std::pow(features[i][j] - centroids[clusterIdx][j], 2);
+        }
+        distance = std::sqrt(distance);
+
+        if (distance < minDistances[clusterIdx]) {
+            minDistances[clusterIdx] = distance;
+            centralRaysIndices[clusterIdx] = i;
+        }
+    }
+
+    return centralRaysIndices;
+}
+
+// The kMeansFilter function implementation
+std::vector<size_t> kMeansFilter(const RAYX::BundleHistory& bundleHist, size_t k) {
+    std::vector<size_t> selectedRays;
+    for (size_t j = 0; j < bundleHist[0].size(); ++j) {  // Assuming all rays have the same number of events
+        auto features = extractFeatures(bundleHist, j);
+        auto [clusterAssignments, centroids] = kMeansClustering(features, k);
+        auto centralRaysIndices = findMostCentralRays(features, clusterAssignments, centroids, k);
+        selectedRays.insert(selectedRays.end(), centralRaysIndices.begin(), centralRaysIndices.end());
+    }
+
+    // Remove duplicate indices if a ray is central in multiple events
+    std::sort(selectedRays.begin(), selectedRays.end());
+    auto last = std::unique(selectedRays.begin(), selectedRays.end());
+    selectedRays.erase(last, selectedRays.end());
+
+    return selectedRays;
+}
+// Function to calculate Euclidean distance between two feature vectors
+float euclideanDistance(const std::vector<float>& a, const std::vector<float>& b) {
+    float distance = 0.0f;
+    for (size_t i = 0; i < a.size(); ++i) {
+        distance += (a[i] - b[i]) * (a[i] - b[i]);
+    }
+    return std::sqrt(distance);
+}
+
+// Function to perform the k-means clustering
+std::pair<std::vector<size_t>, std::vector<std::vector<float>>> kMeansClustering(const std::vector<std::vector<float>>& features, size_t k) {
+    std::vector<std::vector<float>> centroids(k, std::vector<float>(features[0].size(), 0));
+    std::vector<size_t> clusterAssignments(features.size(), 0);
+    std::random_device rd;
+    std::mt19937 rng(rd());
+
+    // Initialize centroids to random features
+    std::uniform_int_distribution<size_t> uni(0, features.size() - 1);
+    for (auto& centroid : centroids) {
+        centroid = features[uni(rng)];
+    }
+
+    bool changed = true;
+    while (changed) {
+        changed = false;
+
+        // Assign clusters
+        for (size_t i = 0; i < features.size(); ++i) {
+            float minDistance = std::numeric_limits<float>::max();
+            size_t clusterIndex = 0;
+            for (size_t j = 0; j < k; ++j) {
+                float distance = euclideanDistance(features[i], centroids[j]);
+                if (distance < minDistance) {
+                    minDistance = distance;
+                    clusterIndex = j;
+                }
+            }
+            if (clusterAssignments[i] != clusterIndex) {
+                clusterAssignments[i] = clusterIndex;
+                changed = true;
+            }
+        }
+
+        // Update centroids
+        std::vector<size_t> counts(k, 0);
+        std::vector<std::vector<float>> sums(k, std::vector<float>(features[0].size(), 0));
+        for (size_t i = 0; i < features.size(); ++i) {
+            size_t clusterIndex = clusterAssignments[i];
+            counts[clusterIndex]++;
+            for (size_t j = 0; j < features[i].size(); ++j) {
+                sums[clusterIndex][j] += features[i][j];
+            }
+        }
+
+        for (size_t i = 0; i < k; ++i) {
+            if (counts[i] == 0) continue;  // Avoid division by zero
+            for (size_t j = 0; j < centroids[i].size(); ++j) {
+                centroids[i][j] = sums[i][j] / counts[i];
+            }
+        }
+    }
+
+    return {clusterAssignments, centroids};
+}

--- a/Intern/rayx-ui/src/RayProcessing.cpp
+++ b/Intern/rayx-ui/src/RayProcessing.cpp
@@ -217,7 +217,7 @@ std::pair<std::vector<size_t>, std::vector<std::vector<float>>> kMeansClustering
         centroid = features[uni(rng)];
     }
 
-    int maxIterations = 100;  // Set a reasonable limit for iterations
+    int maxIterations = 25;  // Set a reasonable limit for iterations
     int iteration = 0;
     bool changed = true;
     while (changed && iteration < maxIterations) {

--- a/Intern/rayx-ui/src/RayProcessing.cpp
+++ b/Intern/rayx-ui/src/RayProcessing.cpp
@@ -24,9 +24,13 @@ std::vector<Line> getRays(const RAYX::BundleHistory& bundleHist, const std::vect
     std::vector<Line> rays;
 
     // Apply the filter function to get the indices of the rays to be rendered
-    std::vector<size_t> rayIndices = filterFunction(bundleHist, amountOfRays);  // k needs to be defined or passed into this function
+    std::vector<size_t> rayIndices = filterFunction(bundleHist, amountOfRays);
+    auto maxRays = bundleHist.size();
     for (size_t i : rayIndices) {
-        // RAYX_LOG << "Ray index: " << i;
+        if (i >= maxRays) {
+            RAYX_VERB << "Ray index out of bounds: " << i;
+            continue;
+        }
         auto& rayHist = bundleHist[i];
         glm::vec3 rayLastPos = {0.0f, 0.0f, 0.0f};
         for (const auto& event : rayHist) {

--- a/Intern/rayx-ui/src/RayProcessing.cpp
+++ b/Intern/rayx-ui/src/RayProcessing.cpp
@@ -11,7 +11,14 @@
 #include "Application.h"
 #include "Colors.h"
 
-void displayFilterSlider(int* amountOfRays, int maxAmountOfRays) {
+void displayFilterSlider(int* amountOfRays, int maxAmountOfRays, bool* displayRays) {
+    // Checkbox for displaying rays
+    // Slider should be greyed out if "Display Rays" is unchecked
+    ImGui::Checkbox("Display Rays", displayRays);
+    if (!*displayRays) {
+        ImGui::BeginDisabled();  // Grey out the slider
+    }
+
     *amountOfRays = std::min(*amountOfRays, maxAmountOfRays);
     ImGui::Text("Maximum amount of Rays per optical element:");
 
@@ -31,7 +38,12 @@ void displayFilterSlider(int* amountOfRays, int maxAmountOfRays) {
     // Display the actual number of rays next to the slider
     ImGui::SameLine();
     ImGui::Text("%d", *amountOfRays);
+
+    if (!*displayRays) {
+        ImGui::EndDisabled();  // End grey out
+    }
 }
+
 size_t getMaxEvents(const RAYX::BundleHistory& bundleHist) {
     size_t maxEvents = 0;
     for (const auto& ray : bundleHist) {

--- a/Intern/rayx-ui/src/RayProcessing.h
+++ b/Intern/rayx-ui/src/RayProcessing.h
@@ -4,6 +4,7 @@
 
 #include "RenderObject.h"
 #include "Tracer/Tracer.h"
+#define MAX_RAYS 1000
 
 // Definition of the RayFilterFunction type
 using RayFilterFunction = std::function<std::vector<size_t>(const RAYX::BundleHistory&, size_t)>;

--- a/Intern/rayx-ui/src/RayProcessing.h
+++ b/Intern/rayx-ui/src/RayProcessing.h
@@ -18,7 +18,7 @@ using RayFilterFunction = std::function<std::vector<size_t>(const RAYX::BundleHi
 
 void displayFilterSlider(int* amountOfRays, int maxAmountOfRays);
 
-std::vector<Line> getRays(const RAYX::BundleHistory& bundleHist, const std::vector<RAYX::OpticalElement>& elements, RayFilterFunction filterFunction,
+std::vector<Line> getRays(const RAYX::BundleHistory& rayCache, const std::vector<RAYX::OpticalElement>& elements, RayFilterFunction filterFunction,
                           int amountOfRays);
 
 std::vector<size_t> findMostCentralRays(const std::vector<std::vector<double>>& features, const std::vector<size_t>& clusterAssignments,
@@ -31,3 +31,4 @@ float euclideanDistance(const std::vector<float>& a, const std::vector<float>& b
 void initializeCentroids(std::vector<std::vector<float>>& centroids, const std::vector<std::vector<float>>& features, size_t k);
 
 std::pair<std::vector<size_t>, std::vector<std::vector<float>>> kMeansClustering(const std::vector<std::vector<float>>& features, size_t k);
+size_t getMaxEvents(const RAYX::BundleHistory& bundleHist);

--- a/Intern/rayx-ui/src/RayProcessing.h
+++ b/Intern/rayx-ui/src/RayProcessing.h
@@ -16,8 +16,6 @@ using RayFilterFunction = std::function<std::vector<size_t>(const RAYX::BundleHi
  * @return A vector of lines, which visually represents the paths of rays in the beamline.
  */
 
-void displayFilterSlider(int* amountOfRays, int maxAmountOfRays);
-
 std::vector<Line> getRays(const RAYX::BundleHistory& rayCache, const std::vector<RAYX::OpticalElement>& elements, RayFilterFunction filterFunction,
                           int amountOfRays);
 
@@ -31,4 +29,5 @@ float euclideanDistance(const std::vector<float>& a, const std::vector<float>& b
 void initializeCentroids(std::vector<std::vector<float>>& centroids, const std::vector<std::vector<float>>& features, size_t k);
 
 std::pair<std::vector<size_t>, std::vector<std::vector<float>>> kMeansClustering(const std::vector<std::vector<float>>& features, size_t k);
+void displayFilterSlider(int* amountOfRays, int maxAmountOfRays, bool* displayRays);
 size_t getMaxEvents(const RAYX::BundleHistory& bundleHist);

--- a/Intern/rayx-ui/src/RayProcessing.h
+++ b/Intern/rayx-ui/src/RayProcessing.h
@@ -1,0 +1,27 @@
+#pragma once
+#include <functional>
+#include <vector>
+
+#include "RenderObject.h"
+#include "Tracer/Tracer.h"
+
+// Definition of the RayFilterFunction type
+using RayFilterFunction = std::function<std::vector<size_t>(const RAYX::BundleHistory&, size_t)>;
+
+/**
+ * @brief Generates visual representations of rays based on bundle history and optical elements.
+ * @param bundleHist RAYX-Core type, providing details of ray interactions in the beamline.
+ * @param elements A vector of optical elements used for coordinate conversions.
+ * @return A vector of lines, which visually represents the paths of rays in the beamline.
+ */
+
+std::vector<Line> getRays(const RAYX::BundleHistory& bundleHist, const std::vector<RAYX::OpticalElement>& elements, RayFilterFunction filterFunction);
+
+std::vector<size_t> findMostCentralRays(const std::vector<std::vector<double>>& features, const std::vector<size_t>& clusterAssignments,
+                                        const std::vector<std::vector<double>>& centroids, size_t k);
+
+std::vector<size_t> kMeansFilter(const RAYX::BundleHistory& bundleHist, size_t k);
+
+float euclideanDistance(const std::vector<float>& a, const std::vector<float>& b);
+
+std::pair<std::vector<size_t>, std::vector<std::vector<float>>> kMeansClustering(const std::vector<std::vector<float>>& features, size_t k);

--- a/Intern/rayx-ui/src/RayProcessing.h
+++ b/Intern/rayx-ui/src/RayProcessing.h
@@ -15,7 +15,10 @@ using RayFilterFunction = std::function<std::vector<size_t>(const RAYX::BundleHi
  * @return A vector of lines, which visually represents the paths of rays in the beamline.
  */
 
-std::vector<Line> getRays(const RAYX::BundleHistory& bundleHist, const std::vector<RAYX::OpticalElement>& elements, RayFilterFunction filterFunction);
+void displayFilterSlider(int* amountOfRays, int maxAmountOfRays);
+
+std::vector<Line> getRays(const RAYX::BundleHistory& bundleHist, const std::vector<RAYX::OpticalElement>& elements, RayFilterFunction filterFunction,
+                          int amountOfRays);
 
 std::vector<size_t> findMostCentralRays(const std::vector<std::vector<double>>& features, const std::vector<size_t>& clusterAssignments,
                                         const std::vector<std::vector<double>>& centroids, size_t k);
@@ -23,5 +26,7 @@ std::vector<size_t> findMostCentralRays(const std::vector<std::vector<double>>& 
 std::vector<size_t> kMeansFilter(const RAYX::BundleHistory& bundleHist, size_t k);
 
 float euclideanDistance(const std::vector<float>& a, const std::vector<float>& b);
+
+void initializeCentroids(std::vector<std::vector<float>>& centroids, const std::vector<std::vector<float>>& features, size_t k);
 
 std::pair<std::vector<size_t>, std::vector<std::vector<float>>> kMeansClustering(const std::vector<std::vector<float>>& features, size_t k);

--- a/Intern/rayx-ui/src/RenderSystem/UIRenderSystem.cpp
+++ b/Intern/rayx-ui/src/RenderSystem/UIRenderSystem.cpp
@@ -8,6 +8,7 @@
 #include <rapidxml.hpp>
 
 #include "CanonicalizePath.h"
+#include "RayProcessing.h"
 
 void checkVkResult(VkResult result, const char* message) {
     if (result != VK_SUCCESS) {
@@ -210,7 +211,11 @@ void UIRenderSystem::showSceneEditorWindow(UIParameters& uiParams) {
     ImGui::Separator();
     uiParams.camController.displaySettings();
     ImGui::Separator();
-
+    int tempAmountOfRays = uiParams.amountOfRays;
+    displayFilterSlider(&uiParams.amountOfRays, 100);
+    if (tempAmountOfRays != uiParams.amountOfRays) {
+        uiParams.raysChanged = true;
+    }
     ImGui::Text("Application average %.6f ms/frame", uiParams.frameTime * 1000.0f);
 
     ImGui::End();

--- a/Intern/rayx-ui/src/RenderSystem/UIRenderSystem.cpp
+++ b/Intern/rayx-ui/src/RenderSystem/UIRenderSystem.cpp
@@ -211,10 +211,10 @@ void UIRenderSystem::showSceneEditorWindow(UIParameters& uiParams) {
     ImGui::Separator();
     uiParams.camController.displaySettings();
     ImGui::Separator();
-    int tempAmountOfRays = uiParams.amountOfRays;
-    displayFilterSlider(&uiParams.amountOfRays, 100);
-    if (tempAmountOfRays != uiParams.amountOfRays) {
-        uiParams.raysChanged = true;
+    int tempAmountOfRays = uiParams.rayInfo.amountOfRays;
+    displayFilterSlider(&uiParams.rayInfo.amountOfRays, uiParams.rayInfo.maxAmountOfRays);
+    if (tempAmountOfRays != uiParams.rayInfo.amountOfRays) {
+        uiParams.rayInfo.raysChanged = true;
     }
     ImGui::Text("Application average %.6f ms/frame", uiParams.frameTime * 1000.0f);
 

--- a/Intern/rayx-ui/src/RenderSystem/UIRenderSystem.cpp
+++ b/Intern/rayx-ui/src/RenderSystem/UIRenderSystem.cpp
@@ -213,8 +213,9 @@ void UIRenderSystem::showSceneEditorWindow(UIParameters& uiParams) {
     ImGui::Separator();
     if (!uiParams.rmlPath.empty()) {
         int tempAmountOfRays = uiParams.rayInfo.amountOfRays;
-        displayFilterSlider(&uiParams.rayInfo.amountOfRays, uiParams.rayInfo.maxAmountOfRays);
-        if (tempAmountOfRays != uiParams.rayInfo.amountOfRays) {
+        bool tempDisplayRays = uiParams.rayInfo.displayRays;
+        displayFilterSlider(&uiParams.rayInfo.amountOfRays, uiParams.rayInfo.maxAmountOfRays, &uiParams.rayInfo.displayRays);
+        if (tempAmountOfRays != uiParams.rayInfo.amountOfRays || tempDisplayRays != uiParams.rayInfo.displayRays) {
             uiParams.rayInfo.raysChanged = true;
         }
     }

--- a/Intern/rayx-ui/src/RenderSystem/UIRenderSystem.cpp
+++ b/Intern/rayx-ui/src/RenderSystem/UIRenderSystem.cpp
@@ -211,10 +211,12 @@ void UIRenderSystem::showSceneEditorWindow(UIParameters& uiParams) {
     ImGui::Separator();
     uiParams.camController.displaySettings();
     ImGui::Separator();
-    int tempAmountOfRays = uiParams.rayInfo.amountOfRays;
-    displayFilterSlider(&uiParams.rayInfo.amountOfRays, uiParams.rayInfo.maxAmountOfRays);
-    if (tempAmountOfRays != uiParams.rayInfo.amountOfRays) {
-        uiParams.rayInfo.raysChanged = true;
+    if (!uiParams.rmlPath.empty()) {
+        int tempAmountOfRays = uiParams.rayInfo.amountOfRays;
+        displayFilterSlider(&uiParams.rayInfo.amountOfRays, uiParams.rayInfo.maxAmountOfRays);
+        if (tempAmountOfRays != uiParams.rayInfo.amountOfRays) {
+            uiParams.rayInfo.raysChanged = true;
+        }
     }
     ImGui::Text("Application average %.6f ms/frame", uiParams.frameTime * 1000.0f);
 

--- a/Intern/rayx-ui/src/RenderSystem/UIRenderSystem.h
+++ b/Intern/rayx-ui/src/RenderSystem/UIRenderSystem.h
@@ -17,7 +17,9 @@ struct UIParameters {
     CameraController& camController;
     std::filesystem::path rmlPath;
     bool pathChanged;
+    bool raysChanged;
     float frameTime;
+    int amountOfRays;
 };
 
 class UIRenderSystem {

--- a/Intern/rayx-ui/src/RenderSystem/UIRenderSystem.h
+++ b/Intern/rayx-ui/src/RenderSystem/UIRenderSystem.h
@@ -14,6 +14,7 @@
  * UI Parameters such as toggles, paths, etc.
  */
 struct UIRayInfo {
+    bool displayRays;
     bool raysChanged;
     int amountOfRays;
     int maxAmountOfRays;

--- a/Intern/rayx-ui/src/RenderSystem/UIRenderSystem.h
+++ b/Intern/rayx-ui/src/RenderSystem/UIRenderSystem.h
@@ -13,13 +13,17 @@
 /**
  * UI Parameters such as toggles, paths, etc.
  */
+struct UIRayInfo {
+    bool raysChanged;
+    int amountOfRays;
+    int maxAmountOfRays;
+};
 struct UIParameters {
     CameraController& camController;
     std::filesystem::path rmlPath;
     bool pathChanged;
-    bool raysChanged;
     float frameTime;
-    int amountOfRays;
+    UIRayInfo rayInfo;
 };
 
 class UIRenderSystem {


### PR DESCRIPTION
RML is now only loaded once
1000 random rays per optical element are cached
The cached rays are used for clustering
lookAtPoint now has a consistent position and direction