### PR TITLE
Addingg source ID to each ray

### DIFF
--- a/Intern/rayx-core/src/Beamline/Beamline.cpp
+++ b/Intern/rayx-core/src/Beamline/Beamline.cpp
@@ -18,19 +18,25 @@ std::vector<Ray> Beamline::getInputRays(int thread_count) const {
     // count number of rays.
     uint32_t raycount = 0;
 
-    for (const auto& s : m_LightSources) {
-        raycount += s->m_numberOfRays;
+    for (std::shared_ptr<LightSource> lsPtr : m_LightSources) {
+        raycount += lsPtr->m_numberOfRays;
     }
 
     // We add all remaining rays into the rays of the first light source.
     // This is efficient because in most cases there is just one light source, and hence copying them again is unnecessary.
     std::vector<Ray> list = m_LightSources[0]->getRays(thread_count);
+    for (Ray& r : list) {
+        r.m_sourceID = 0;  // the first light source has ID 0.
+    }
 
     if (m_LightSources.size() > 1) {
         list.reserve(raycount);
 
         for (unsigned int i = 1; i < m_LightSources.size(); i++) {
-            auto sub = m_LightSources[i]->getRays(thread_count);
+            std::vector<Ray> sub = m_LightSources[i]->getRays(thread_count);
+            for (Ray& r : sub) {
+                r.m_sourceID = i;
+            }
             list.insert(list.end(), sub.begin(), sub.end());
         }
     }

--- a/Intern/rayx-core/src/Shader/Ray.h
+++ b/Intern/rayx-core/src/Shader/Ray.h
@@ -47,9 +47,10 @@ struct RAYX_API Ray {
     /// is initially set to -1 upon construction by the LightSources.
     double m_lastElement;
 
-    /// This double only exists to address alignment issues (see below).
-    /// m_padding should never be read or written.
-    double m_padding;
+    /// The index of the LightSource that emitted this ray.
+    /// It is initially set to -1 upon construction by the LightSources and later set by the beamline.
+    /// NOTE: This can be moved outside of the Ray struct. It is here for convenience.
+    double m_sourceID;
 };
 
 // Note: A `dvec3` needs an alignment of 4 * sizeof(double), hence two dvec3s can never be directly after each other (without padding).
@@ -58,7 +59,6 @@ struct RAYX_API Ray {
 #ifndef GLSL
 static_assert(sizeof(Ray) % alignof(dvec3) == 0);
 #endif
-
 
 #ifndef GLSL
 }  // namespace RAYX

--- a/Intern/rayx-core/src/Writer/CSVWriter.cpp
+++ b/Intern/rayx-core/src/Writer/CSVWriter.cpp
@@ -112,7 +112,7 @@ RAYX::BundleHistory loadCSV(const std::string& filename) {
         while (std::getline(ss, num, DELIMITER)) {
             d.push_back(std::stod(num));
         }
-        assert(d.size() == 15);
+        assert(d.size() == 16);
         RAYX::Ray ray = {.m_position = {d[0], d[1], d[2]},
                          .m_eventType = d[3],
                          .m_direction = {d[4], d[5], d[6]},
@@ -121,7 +121,7 @@ RAYX::BundleHistory loadCSV(const std::string& filename) {
                          .m_pathLength = d[12],
                          .m_order = d[13],
                          .m_lastElement = d[14],
-                         .m_padding = -1.0};
+                         .m_sourceID = d[15]};
         if (out.size() <= ray_id) {
             out.emplace_back();
         }

--- a/Intern/rayx-core/src/Writer/H5Writer.cpp
+++ b/Intern/rayx-core/src/Writer/H5Writer.cpp
@@ -91,9 +91,10 @@ RAYX::BundleHistory fromDoubles(const std::vector<double>& doubles, const Format
         double pathLength = doubles[double_index + 12];
         double order = doubles[double_index + 13];
         double lastElement = doubles[double_index + 14];
+        double sourceID = doubles[double_index + 15];
 
         RAYX::Ray ray = {
-            origin, eventType, direction, energy, stokes, pathLength, order, lastElement, 0.0,
+            origin, eventType, direction, energy, stokes, pathLength, order, lastElement, sourceID,
         };
 
         rayHist.push_back(ray);

--- a/Intern/rayx-core/src/Writer/Writer.h
+++ b/Intern/rayx-core/src/Writer/Writer.h
@@ -95,6 +95,10 @@ static Format FULL_FORMAT = {
         .name = "lastElement",
         .get_double = [](uint, uint, RAYX::Ray ray) { return ray.m_lastElement; },
     },
+    FormatComponent{
+        .name = "lightSourceIndex",
+        .get_double = [](uint, uint, RAYX::Ray ray) { return ray.m_sourceID; },
+    },
 };
 
 // These includes allow the user to just import Writer.h and still access

--- a/Intern/rayx-core/tests/setupTests.cpp
+++ b/Intern/rayx-core/tests/setupTests.cpp
@@ -48,7 +48,7 @@ RAYX::Ray parseCSVline(std::string line) {
     ray.m_stokes = {vec[11], vec[12], vec[13], vec[14]};
 
     // otherwise uninitialized:
-    ray.m_padding = -1;
+    ray.m_sourceID = -1;
     ray.m_eventType = -1;
     ray.m_lastElement = -1;
     ray.m_order = -1;

--- a/Intern/rayx-ui/src/Triangulation/TraceTriangulation.cpp
+++ b/Intern/rayx-ui/src/Triangulation/TraceTriangulation.cpp
@@ -33,7 +33,7 @@ std::vector<std::vector<RAYX::Ray>> createRayGrid(size_t size, double width, dou
                 .m_pathLength = 0.0f,
                 .m_order = 0.0f,
                 .m_lastElement = -1.0f,
-                .m_padding = 0.0f,
+                .m_sourceID = 0.0f,
             };
             grid[i][j] = ray;
         }


### PR DESCRIPTION
Here is a hack so each ray saves the ID of the light source it originated from. I need to know what ray belongs to which source for the frontend. 

The Ray does not necessarily need to know its source. We could also have an external data structure that maps Ray-ID to the light sources' ID if we need the space in the Ray struct.

I probably need to do more testing to make sure I did not break any IO stuff.