### PR TITLE
Seperate Vertex into TexVertex and ColorVertex

### DIFF
--- a/Intern/rayx-ui/src/Application.cpp
+++ b/Intern/rayx-ui/src/Application.cpp
@@ -262,7 +262,7 @@ void Application::updateRays(BundleHistory& rayCache, std::optional<RenderObject
     }
     if (!rays.empty()) {
         // Temporarily aggregate all vertices, then create a single RenderObject
-        std::vector<Vertex> rayVertices(rays.size() * 2);
+        std::vector<ColorVertex> rayVertices(rays.size() * 2);
         std::vector<uint32_t> rayIndices(rays.size() * 2);
         for (uint32_t i = 0; i < rays.size(); ++i) {
             rayVertices[i * 2] = rays[i].v1;
@@ -275,6 +275,12 @@ void Application::updateRays(BundleHistory& rayCache, std::optional<RenderObject
             DescriptorPool::Builder(m_Device).addPoolSize(VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1).setMaxSets(1).build();
         std::shared_ptr<DescriptorSetLayout> raySetLayout =
             DescriptorSetLayout::Builder(m_Device).addBinding(0, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, VK_SHADER_STAGE_FRAGMENT_BIT).build();
-        rayObj.emplace(m_Device, glm::mat4(1.0f), rayVertices, rayIndices, Texture(m_Device), raySetLayout, rayDescrPool);
+
+        std::vector<std::shared_ptr<Vertex>> shared_vertices;
+        shared_vertices.reserve(rayVertices.size());
+        std::transform(rayVertices.begin(), rayVertices.end(), std::back_inserter(shared_vertices),
+                       [](const ColorVertex& vertex) { return std::make_shared<ColorVertex>(vertex); });
+
+        rayObj.emplace(m_Device, glm::mat4(1.0f), shared_vertices, rayIndices, Texture(m_Device), raySetLayout, rayDescrPool);
     }
 }

--- a/Intern/rayx-ui/src/GraphicsCore/GraphicsPipeline.cpp
+++ b/Intern/rayx-ui/src/GraphicsCore/GraphicsPipeline.cpp
@@ -122,7 +122,7 @@ void GraphicsPipeline::createShaderModule(const std::vector<char>& code, VkShade
 
 void GraphicsPipeline::bind(VkCommandBuffer commandBuffer) { vkCmdBindPipeline(commandBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS, m_Pipeline); }
 
-void GraphicsPipeline::defaultPipelineConfigInfo(PipelineConfigInfo& configInfo) {
+void GraphicsPipeline::defaultPipelineConfigInfo(PipelineConfigInfo& configInfo, VertexMode vertexMode) {
     configInfo.inputAssemblyInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO;
     configInfo.inputAssemblyInfo.topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
     configInfo.inputAssemblyInfo.primitiveRestartEnable = VK_FALSE;
@@ -190,6 +190,11 @@ void GraphicsPipeline::defaultPipelineConfigInfo(PipelineConfigInfo& configInfo)
     configInfo.dynamicStateInfo.dynamicStateCount = static_cast<uint32_t>(configInfo.dynamicStateEnables.size());
     configInfo.dynamicStateInfo.flags = 0;
 
-    configInfo.bindingDescriptions = Vertex::getBindingDescriptions();
-    configInfo.attributeDescriptions = Vertex::getAttributeDescriptions();
+    if (vertexMode == VertexMode::TEXTURED) {
+        configInfo.bindingDescriptions = TexVertex::getBindingDescriptions();
+        configInfo.attributeDescriptions = TexVertex::getAttributeDescriptions();
+    } else {
+        configInfo.bindingDescriptions = ColorVertex::getBindingDescriptions();
+        configInfo.attributeDescriptions = ColorVertex::getAttributeDescriptions();
+    }
 }

--- a/Intern/rayx-ui/src/GraphicsCore/GraphicsPipeline.h
+++ b/Intern/rayx-ui/src/GraphicsCore/GraphicsPipeline.h
@@ -35,6 +35,7 @@ struct PipelineConfigInfo {
  */
 class GraphicsPipeline {
   public:
+    enum class VertexMode { COLORED, TEXTURED };
     GraphicsPipeline(Device& device, const std::string& vertFilepath, const std::string& fragFilepath, const PipelineConfigInfo& createInfo);
     ~GraphicsPipeline();
 
@@ -48,7 +49,7 @@ class GraphicsPipeline {
      *
      * @param configInfo The configuration information to be filled with default values.
      */
-    static void defaultPipelineConfigInfo(PipelineConfigInfo& configInfo);
+    static void defaultPipelineConfigInfo(PipelineConfigInfo& configInfo, VertexMode vertexMode = VertexMode::TEXTURED);
     VkPipeline getHandle() const { return m_Pipeline; }
 
   private:

--- a/Intern/rayx-ui/src/RayProcessing.cpp
+++ b/Intern/rayx-ui/src/RayProcessing.cpp
@@ -92,8 +92,8 @@ std::vector<Line> getRays(const RAYX::BundleHistory& rayCache, const RAYX::Beaml
             glm::vec4 originColor = (event.m_eventType == ETYPE_JUST_HIT_ELEM) ? YELLOW : WHITE;
             glm::vec4 pointColor = (event.m_eventType == ETYPE_JUST_HIT_ELEM) ? ORANGE : (event.m_eventType == ETYPE_ABSORBED) ? RED : WHITE;
 
-            Vertex origin = {rayLastPos, originColor, {0.0f, 0.0f}};
-            Vertex point = {worldPos, pointColor, {0.0f, 0.0f}};
+            ColorVertex origin = {rayLastPos, originColor};
+            ColorVertex point = {worldPos, pointColor};
 
             rays.push_back(Line(origin, point));
             rayLastPos = point.pos;

--- a/Intern/rayx-ui/src/RenderObject.h
+++ b/Intern/rayx-ui/src/RenderObject.h
@@ -12,13 +12,13 @@
 #include "Vertex.h"
 
 struct Triangle {
-    Vertex v1;
-    Vertex v2;
-    Vertex v3;
+    TexVertex v1;
+    TexVertex v2;
+    TexVertex v3;
 };
 struct Line {
-    Vertex v1;
-    Vertex v2;
+    ColorVertex v1;
+    ColorVertex v2;
 };
 
 /**
@@ -38,8 +38,8 @@ class RenderObject {
      * @param vertices Vector of Vertex objects.
      * @param indices Vector of index values.
      */
-    RenderObject(Device& device, glm::mat4 modelMatrix, std::vector<Vertex>& vertices, std::vector<uint32_t>& indices, Texture&& texture,
-                 std::shared_ptr<DescriptorSetLayout> setLayout, std::shared_ptr<DescriptorPool> descriptorPool);
+    RenderObject(Device& device, glm::mat4 modelMatrix, std::vector<std::shared_ptr<Vertex>> vertices, std::vector<uint32_t>& indices,
+                 Texture&& texture, std::shared_ptr<DescriptorSetLayout> setLayout, std::shared_ptr<DescriptorPool> descriptorPool);
     RenderObject(const RenderObject&) = delete;
     RenderObject& operator=(const RenderObject&) = delete;
     RenderObject(RenderObject&& other) noexcept;
@@ -70,7 +70,7 @@ class RenderObject {
     VkDescriptorSet getDescriptorSet() const { return m_descrSet; }
 
   private:
-    void createVertexBuffers(const std::vector<Vertex>& vertices);
+    void createVertexBuffers(const std::vector<std::shared_ptr<Vertex>> vertices);
     void createIndexBuffers(const std::vector<uint32_t>& indices);
     void createDescriptorSet();
 

--- a/Intern/rayx-ui/src/RenderSystem/RayRenderSystem.cpp
+++ b/Intern/rayx-ui/src/RenderSystem/RayRenderSystem.cpp
@@ -39,7 +39,7 @@ void RayRenderSystem::createPipeline(VkRenderPass renderPass) {
     assert(m_PipelineLayout != nullptr && "Cannot create pipeline before pipeline layout");
 
     PipelineConfigInfo pipelineConfig{};
-    GraphicsPipeline::defaultPipelineConfigInfo(pipelineConfig);
+    GraphicsPipeline::defaultPipelineConfigInfo(pipelineConfig, GraphicsPipeline::VertexMode::COLORED);
     pipelineConfig.inputAssemblyInfo.topology = VK_PRIMITIVE_TOPOLOGY_LINE_LIST;
     pipelineConfig.rasterizationInfo.polygonMode = VK_POLYGON_MODE_LINE;
     pipelineConfig.rasterizationInfo.lineWidth = 2.0f;

--- a/Intern/rayx-ui/src/Shaders/ray_shader.frag
+++ b/Intern/rayx-ui/src/Shaders/ray_shader.frag
@@ -1,7 +1,6 @@
 #version 450
 
 layout(location = 0) in vec4 fragColor;
-layout(location = 1) in vec2 fragTexCoord;
 
 layout(location = 0) out vec4 outColor;
 

--- a/Intern/rayx-ui/src/Shaders/ray_shader.vert
+++ b/Intern/rayx-ui/src/Shaders/ray_shader.vert
@@ -9,13 +9,10 @@ layout(binding = 0) uniform Camera {
 
 layout(location = 0) in vec4 inPosition;
 layout(location = 1) in vec4 inColor;
-layout(location = 2) in vec2 inTexCoord;
 
 layout(location = 0) out vec4 fragColor;
-layout(location = 1) out vec2 fragTexCoord;
 
 void main() {
     gl_Position = cam.proj * cam.view * inPosition;
     fragColor = inColor;
-    fragTexCoord = inTexCoord;
 }

--- a/Intern/rayx-ui/src/Shaders/shader.frag
+++ b/Intern/rayx-ui/src/Shaders/shader.frag
@@ -5,7 +5,6 @@ layout(push_constant) uniform PushConstants {
     mat4 model;
 } push;
 
-layout(location = 0) in vec4 fragColor;
 layout(location = 1) in vec2 fragTexCoord;
 
 layout(set = 1, binding = 0) uniform sampler2D texSampler;

--- a/Intern/rayx-ui/src/Shaders/shader.vert
+++ b/Intern/rayx-ui/src/Shaders/shader.vert
@@ -14,14 +14,11 @@ layout(set = 0, binding = 0) uniform Camera {
 } cam;
 
 layout(location = 0) in vec4 inPosition;
-layout(location = 1) in vec4 inColor;
 layout(location = 2) in vec2 inTexCoord;
 
-layout(location = 0) out vec4 fragColor;
 layout(location = 1) out vec2 fragTexCoord;
 
 void main() {
     gl_Position = cam.proj * cam.view * push.model * inPosition;
-    fragColor = inColor;
     fragTexCoord = inTexCoord;
 }

--- a/Intern/rayx-ui/src/Triangulation/GeometryUtils.cpp
+++ b/Intern/rayx-ui/src/Triangulation/GeometryUtils.cpp
@@ -5,10 +5,10 @@
 void Polygon::calculateForQuadrilateral(double widthA, double widthB, double lengthA, double lengthB) {
     // Right handed coord system when looking down the negative y axis: x is to the left and z is up
     vertices = {
-        Vertex({widthB / 2.0f, 0, -lengthB / 2.0f, 1.0f}, OPT_ELEMENT_COLOR, {0.0f, 1.0f}),  // Bottom-left
-        Vertex({widthA / 2.0f, 0, lengthB / 2.0f, 1.0f}, OPT_ELEMENT_COLOR, {0.0f, 0.0f}),   // Top-left
-        Vertex({-widthA / 2.0f, 0, lengthA / 2.0f, 1.0f}, OPT_ELEMENT_COLOR, {1.0f, 0.0f}),  // Top-right
-        Vertex({-widthB / 2.0f, 0, -lengthA / 2.0f, 1.0f}, OPT_ELEMENT_COLOR, {1.0f, 1.0f})  // Bottom-right
+        TexVertex(glm::vec4(widthB / 2.0f, 0, -lengthB / 2.0f, 1.0f), glm::vec2(0.0f, 1.0f)),  // Bottom-left
+        TexVertex(glm::vec4(widthA / 2.0f, 0, lengthB / 2.0f, 1.0f), glm::vec2(0.0f, 0.0f)),   // Top-left
+        TexVertex(glm::vec4(-widthA / 2.0f, 0, lengthA / 2.0f, 1.0f), glm::vec2(1.0f, 0.0f)),  // Top-right
+        TexVertex(glm::vec4(-widthB / 2.0f, 0, -lengthA / 2.0f, 1.0f), glm::vec2(1.0f, 1.0f))  // Bottom-right
     };
     indices = {0, 1, 2, 2, 3, 0};
 }
@@ -40,12 +40,12 @@ void Polygon::calculateForElliptical(double diameterA, double diameterB) {
  * This function takes a polygon and interpolates it to have the specified number of vertices.
  * The polygon is assumed to be convex.
  */
-void interpolateConvexPolygon(std::vector<Vertex>& polyVertices, uint32_t targetNumber) {
+void interpolateConvexPolygon(std::vector<TexVertex>& polyVertices, uint32_t targetNumber) {
     if (polyVertices.size() == targetNumber || polyVertices.empty()) {
         return;  // No interpolation needed if counts are the same or polygon is empty
     }
 
-    std::vector<Vertex> interpolatedVertices;
+    std::vector<TexVertex> interpolatedVertices;
     interpolatedVertices.reserve(targetNumber);
 
     size_t originalCount = polyVertices.size();
@@ -59,16 +59,16 @@ void interpolateConvexPolygon(std::vector<Vertex>& polyVertices, uint32_t target
         double fraction = exactIndex - lowerIndex;
 
         glm::vec4 interpolatedPosition = glm::mix(polyVertices[lowerIndex].pos, polyVertices[upperIndex].pos, fraction);
-        glm::vec4 interpolatedColor = glm::mix(polyVertices[lowerIndex].color, polyVertices[upperIndex].color, fraction);
 
-        interpolatedVertices.push_back({interpolatedPosition, interpolatedColor, {0.0f, 0.0f}});
+        interpolatedVertices.push_back({interpolatedPosition, {0.0f, 0.0f}});
     }
 
     // Replace the original vertices with the interpolated ones
     polyVertices = std::move(interpolatedVertices);
 }
 
-std::vector<std::vector<double>> calculateDistanceMatrix(const std::vector<Vertex>& outerSlitVertices, const std::vector<Vertex>& openingVertices) {
+std::vector<std::vector<double>> calculateDistanceMatrix(const std::vector<TexVertex>& outerSlitVertices,
+                                                         const std::vector<TexVertex>& openingVertices) {
     uint32_t numOuterSlitVertices = (uint32_t)outerSlitVertices.size();
     uint32_t numOpeningVertices = (uint32_t)openingVertices.size();
 

--- a/Intern/rayx-ui/src/Triangulation/GeometryUtils.h
+++ b/Intern/rayx-ui/src/Triangulation/GeometryUtils.h
@@ -5,7 +5,7 @@
 struct Vertex;
 
 struct Polygon {
-    std::vector<Vertex> vertices;
+    std::vector<TexVertex> vertices;
     std::vector<uint32_t> indices;
 
     void calculateForQuadrilateral(double widthA, double widthB, double lengthA, double lengthB);
@@ -16,9 +16,10 @@ struct Polygon {
  * This function takes a polygon and interpolates it to have the specified number of vertices.
  * The polygon is assumed to be convex.
  */
-void interpolateConvexPolygon(std::vector<Vertex>& polyVertices, uint32_t targetNumber);
+void interpolateConvexPolygon(std::vector<TexVertex>& polyVertices, uint32_t targetNumber);
 
-std::vector<std::vector<double>> calculateDistanceMatrix(const std::vector<Vertex>& outerSlitVertices, const std::vector<Vertex>& openingVertices);
+std::vector<std::vector<double>> calculateDistanceMatrix(const std::vector<TexVertex>& outerSlitVertices,
+                                                         const std::vector<TexVertex>& openingVertices);
 
 /**
  * @brief Returns the dimensions (width and length) for various types of cutouts.

--- a/Intern/rayx-ui/src/Triangulation/TraceTriangulation.cpp
+++ b/Intern/rayx-ui/src/Triangulation/TraceTriangulation.cpp
@@ -47,7 +47,7 @@ std::vector<std::vector<RAYX::Ray>> createRayGrid(size_t size, double width, dou
  * cutout. Using CPU-based ray tracing, it computes the intersections between rays and the optical element's surface within the cutout. The ray
  * intersections are then grouped into triangles based on the grid, and a RenderObject representing these triangles is returned.
  */
-void traceTriangulation(const RAYX::OpticalElement& element, std::vector<Vertex>& vertices, std::vector<uint32_t>& indices) {
+void traceTriangulation(const RAYX::OpticalElement& element, std::vector<TexVertex>& vertices, std::vector<uint32_t>& indices) {
     RAYX::CpuTracer tracer;
 
     constexpr size_t gridSize = 100;

--- a/Intern/rayx-ui/src/Triangulation/TraceTriangulation.h
+++ b/Intern/rayx-ui/src/Triangulation/TraceTriangulation.h
@@ -23,7 +23,7 @@
  *   RenderObject renderObj = traceTriangulation(element, device);
  * @endcode
  */
-void traceTriangulation(const RAYX::OpticalElement& element, std::vector<Vertex>& vertices, std::vector<uint32_t>& indices);
+void traceTriangulation(const RAYX::OpticalElement& element, std::vector<TexVertex>& vertices, std::vector<uint32_t>& indices);
 
 // ------ Helper functions ------
 

--- a/Intern/rayx-ui/src/Triangulation/Triangulate.cpp
+++ b/Intern/rayx-ui/src/Triangulation/Triangulate.cpp
@@ -12,7 +12,7 @@
 
 // ------ Helper functions ------
 
-void calculateSolidMeshOfType(const Cutout& cutout, std::vector<Vertex>& vertices, std::vector<uint32_t>* indices = nullptr) {
+void calculateSolidMeshOfType(const Cutout& cutout, std::vector<TexVertex>& vertices, std::vector<uint32_t>* indices = nullptr) {
     constexpr double defWidthHeight = 50.0f;  // TODO(Jannis): define this in one place (@see getRectangularDimensions)
     Polygon poly;
 
@@ -49,7 +49,7 @@ void calculateSolidMeshOfType(const Cutout& cutout, std::vector<Vertex>& vertice
     vertices.insert(vertices.end(), poly.vertices.begin(), poly.vertices.end());
 }
 
-void calculateMeshForSlit(const Element& element, std::vector<Vertex>& vertices, std::vector<uint32_t>& indices) {
+void calculateMeshForSlit(const Element& element, std::vector<TexVertex>& vertices, std::vector<uint32_t>& indices) {
     // Deserialize to get SlitBehaviour
     SlitBehaviour slit = deserializeSlit(element.m_behaviour);
 
@@ -57,11 +57,11 @@ void calculateMeshForSlit(const Element& element, std::vector<Vertex>& vertices,
     calculateSolidMeshOfType(slit.m_beamstopCutout, vertices, &indices);
 
     // Calculate vertices for the outer slit
-    std::vector<Vertex> outerSlitVertices;
+    std::vector<TexVertex> outerSlitVertices;
     calculateSolidMeshOfType(element.m_cutout, outerSlitVertices);
 
     // Calculate vertices for the opening
-    std::vector<Vertex> openingVertices;
+    std::vector<TexVertex> openingVertices;
     calculateSolidMeshOfType(slit.m_openingCutout, openingVertices);
 
     uint32_t numOuterSlitVertices = (uint32_t)outerSlitVertices.size();
@@ -117,7 +117,7 @@ void calculateMeshForSlit(const Element& element, std::vector<Vertex>& vertices,
     }
 }
 
-void planarTriangulation(const RAYX::OpticalElement& element, std::vector<Vertex>& vertices, std::vector<uint32_t>& indices) {
+void planarTriangulation(const RAYX::OpticalElement& element, std::vector<TexVertex>& vertices, std::vector<uint32_t>& indices) {
     // The slit behaviour needs special attention, since it is basically three cutouts (the slit, the beamstop and the opening)
     if (element.m_element.m_behaviour.m_type == BTYPE_SLIT) {
         calculateMeshForSlit(element.m_element, vertices, indices);
@@ -133,7 +133,7 @@ bool isPlanar(const QuadricSurface& q) { return (q.m_a11 == 0 && q.m_a22 == 0 &&
 /**
  * This function takes optical elements and categorizes them for efficient triangulation.
  */
-void triangulateObject(const RAYX::OpticalElement& element, std::vector<Vertex>& vertices, std::vector<uint32_t>& indices) {
+void triangulateObject(const RAYX::OpticalElement& element, std::vector<TexVertex>& vertices, std::vector<uint32_t>& indices) {
     switch (static_cast<int>(element.m_element.m_surface.m_type)) {
         case STYPE_PLANE_XZ: {
             planarTriangulation(element, vertices, indices);

--- a/Intern/rayx-ui/src/Triangulation/Triangulate.h
+++ b/Intern/rayx-ui/src/Triangulation/Triangulate.h
@@ -11,4 +11,4 @@
  * @param elements A vector of optical elements to be triangulated.
  * @return A vector of RenderObject, which are the triangulated version of the input elements.
  */
-void triangulateObject(const RAYX::OpticalElement& elements, std::vector<Vertex>& vertices, std::vector<uint32_t>& indices);
+void triangulateObject(const RAYX::OpticalElement& elements, std::vector<TexVertex>& vertices, std::vector<uint32_t>& indices);

--- a/Intern/rayx-ui/src/Vertex.h
+++ b/Intern/rayx-ui/src/Vertex.h
@@ -5,9 +5,37 @@
 #include <array>
 #include <glm/glm.hpp>
 
-/* TODO(Jannis): Divide normal and textured vertices into separate structs so rays don't need to have texture coordinates.
- *               This would allow cleaning up the ray shader.
+/**
+ * @struct Vertex
+ * @brief A structure representing a Vertex in 3D space.
+ *
+ * This structure contains position data for a vertex. It also provides methods
+ * to generate Vulkan-specific descriptions for vertex input bindings and vertex input attributes.
  */
+struct Vertex {
+    /// @brief 4D vector representing the position of the vertex.
+    glm::vec4 pos;
+
+    Vertex() = default;
+    Vertex(glm::vec3 pos) : pos(glm::vec4(pos, 1.0f)) {}
+    Vertex(glm::vec4 pos) : pos(pos) {}
+
+    virtual bool operator==(const Vertex& other) const = 0;
+
+    std::vector<VkVertexInputBindingDescription> getBindingDescriptions() const {
+        std::vector<VkVertexInputBindingDescription> bindingDescriptions(1);
+        bindingDescriptions[0].binding = 0;
+        bindingDescriptions[0].stride = sizeof(Vertex);
+        bindingDescriptions[0].inputRate = VK_VERTEX_INPUT_RATE_VERTEX;
+        return bindingDescriptions;
+    }
+
+    std::vector<VkVertexInputAttributeDescription> getAttributeDescriptions() const {
+        std::vector<VkVertexInputAttributeDescription> attributeDescriptions{};
+        attributeDescriptions.push_back({0, 0, VK_FORMAT_R32G32B32A32_SFLOAT, offsetof(Vertex, pos)});
+        return attributeDescriptions;
+    }
+};
 
 /**
  * @struct Vertex
@@ -16,16 +44,22 @@
  * This structure contains position and color data for a vertex. It also provides methods
  * to generate Vulkan-specific descriptions for vertex input bindings and vertex input attributes.
  */
-struct Vertex {
-    /// @brief 4D vector representing the position of the vertex.
-    glm::vec4 pos;
-    /// @brief 4D vector representing the color of the vertex.
-    glm::vec4 color;
+struct TexVertex : public Vertex {
     /// @brief 2D vector representing the texture coordinates of the vertex.
-    glm::vec2 texCoord;
+    glm::vec2 uv;
+
+    TexVertex() = default;
+    TexVertex(glm::vec3 pos, glm::vec2 uv) : Vertex(pos), uv(uv) {}
+    TexVertex(glm::vec4 pos, glm::vec2 uv) : Vertex(pos), uv(uv) {}
 
     /// @brief Equality operator for Vertex objects.
-    bool operator==(const Vertex& other) const { return pos == other.pos && color == other.color; }
+    bool operator==(const Vertex& other) const override {
+        if (const TexVertex* v = dynamic_cast<const TexVertex*>(&other)) {
+            return pos == v->pos && uv == v->uv;
+        } else {
+            return false;
+        }
+    }
 
     /**
      * @brief Generate Vulkan vertex input binding descriptions.
@@ -37,7 +71,7 @@ struct Vertex {
     static std::vector<VkVertexInputBindingDescription> getBindingDescriptions() {
         std::vector<VkVertexInputBindingDescription> bindingDescriptions(1);
         bindingDescriptions[0].binding = 0;
-        bindingDescriptions[0].stride = sizeof(Vertex);
+        bindingDescriptions[0].stride = sizeof(TexVertex);
         bindingDescriptions[0].inputRate = VK_VERTEX_INPUT_RATE_VERTEX;
         return bindingDescriptions;
     }
@@ -51,9 +85,64 @@ struct Vertex {
      */
     static std::vector<VkVertexInputAttributeDescription> getAttributeDescriptions() {
         std::vector<VkVertexInputAttributeDescription> attributeDescriptions{};
-        attributeDescriptions.push_back({0, 0, VK_FORMAT_R32G32B32_SFLOAT, offsetof(Vertex, pos)});
-        attributeDescriptions.push_back({1, 0, VK_FORMAT_R32G32B32_SFLOAT, offsetof(Vertex, color)});
-        attributeDescriptions.push_back({2, 0, VK_FORMAT_R32G32_SFLOAT, offsetof(Vertex, texCoord)});
+        attributeDescriptions.push_back({0, 0, VK_FORMAT_R32G32B32_SFLOAT, offsetof(TexVertex, pos)});
+        attributeDescriptions.push_back({2, 0, VK_FORMAT_R32G32_SFLOAT, offsetof(TexVertex, uv)});
+        return attributeDescriptions;
+    }
+};
+
+/**
+ * @struct Vertex
+ * @brief A structure representing a Vertex in 3D space with additional color information.
+ *
+ * This structure contains position and color data for a vertex. It also provides methods
+ * to generate Vulkan-specific descriptions for vertex input bindings and vertex input attributes.
+ */
+struct ColorVertex : public Vertex {
+    /// @brief 4D vector representing the color of the vertex.
+    glm::vec4 color;
+
+    ColorVertex() = default;
+    ColorVertex(glm::vec3 pos, glm::vec3 color) : Vertex(pos), color(glm::vec4(color, 1.0f)) {}
+    ColorVertex(glm::vec3 pos, glm::vec4 color) : Vertex(pos), color(color) {}
+    ColorVertex(glm::vec4 pos, glm::vec3 color) : Vertex(pos), color(glm::vec4(color, 1.0f)) {}
+    ColorVertex(glm::vec4 pos, glm::vec4 color) : Vertex(pos), color(color) {}
+
+    /// @brief Equality operator for Vertex objects.
+    bool operator==(const Vertex& other) const override {
+        if (const ColorVertex* v = dynamic_cast<const ColorVertex*>(&other)) {
+            return pos == v->pos && color == v->color;
+        } else {
+            return false;
+        }
+    }
+
+    /**
+     * @brief Generate Vulkan vertex input binding descriptions.
+     *
+     * Provides Vulkan-specific descriptions required for vertex input binding.
+     *
+     * @return A vector of VkVertexInputBindingDescription objects.
+     */
+    static std::vector<VkVertexInputBindingDescription> getBindingDescriptions() {
+        std::vector<VkVertexInputBindingDescription> bindingDescriptions(1);
+        bindingDescriptions[0].binding = 0;
+        bindingDescriptions[0].stride = sizeof(ColorVertex);
+        bindingDescriptions[0].inputRate = VK_VERTEX_INPUT_RATE_VERTEX;
+        return bindingDescriptions;
+    }
+
+    /**
+     * @brief Generate Vulkan vertex input attribute descriptions.
+     *
+     * Provides Vulkan-specific descriptions required for vertex input attributes.
+     *
+     * @return A vector of VkVertexInputAttributeDescription objects.
+     */
+    static std::vector<VkVertexInputAttributeDescription> getAttributeDescriptions() {
+        std::vector<VkVertexInputAttributeDescription> attributeDescriptions{};
+        attributeDescriptions.push_back({0, 0, VK_FORMAT_R32G32B32_SFLOAT, offsetof(ColorVertex, pos)});
+        attributeDescriptions.push_back({1, 0, VK_FORMAT_R32G32B32A32_SFLOAT, offsetof(ColorVertex, color)});
         return attributeDescriptions;
     }
 };


### PR DESCRIPTION
This is a rough implementation of what it would take to remove the color field from the Vertex struct (#242). I'm not happy with it but it significantly reduces the size of the vertex data moved to the GPU. 

@EnricoAhlers, what is your opinion? Do you think this is worth it?

If this should stay: I still need to clean it up a bit. Some benchmarking is a good idea too.