### PR TITLE
Implementation of startEventID

### DIFF
--- a/Intern/rayx-core/src/Shader/Helper.cpp
+++ b/Intern/rayx-core/src/Shader/Helper.cpp
@@ -6,7 +6,7 @@ void init() {
     inv_finalized = false;
 
     // sets all output rays controlled by this shader call to ETYPE_UNINIT.
-    for (uint i = 0; i < inv_pushConstants.maxEvents; i++) {
+    for (uint i = uint(inv_pushConstants.startEventID); i < inv_pushConstants.maxEvents; i++) {
         inv_outputData[output_index(i)].m_eventType = ETYPE_UNINIT;
     }
     inv_nextEventIndex = 0;
@@ -24,7 +24,10 @@ uint64_t rayId() { return uint64_t(inv_pushConstants.rayIdStart) + uint64_t(gl_G
 // `i in [0, maxEvents-1]`.
 // Will return the index in outputData to access the `i'th` output ray belonging to this shader call.
 // Typically used as `outputData[output_index(i)]`.
-uint output_index(uint i) { return uint(gl_GlobalInvocationID) * uint(inv_pushConstants.maxEvents - inv_pushConstants.startEventID) + i; }
+uint output_index(uint i) {
+    return uint(gl_GlobalInvocationID) * uint(inv_pushConstants.maxEvents - inv_pushConstants.startEventID) + i -
+           uint(inv_pushConstants.startEventID);
+}
 
 // record an event and store it in the next free spot in outputData.
 // `r` will typically be _ray, or some related ray.

--- a/Intern/rayx-core/src/Shader/InvocationState.cpp
+++ b/Intern/rayx-core/src/Shader/InvocationState.cpp
@@ -15,7 +15,6 @@ uint64_t inv_ctr;
 
 uint64_t inv_nextEventIndex;
 
-
 /**************************************************************
  *                    SHADER ARRAYS
  **************************************************************/
@@ -45,19 +44,19 @@ SHADER_ARRAY(double, inv_mat, 5, materialBuf);
 SHADER_ARRAY(_debug_struct, inv_d_struct, 6, debugBuf);
 #endif
 
-
 /**************************************************************
  *                    PushConstants
  **************************************************************/
 #ifndef GLSL
-    PushConstants inv_pushConstants;
-#else 
-    layout( push_constant ) uniform constants
-    {   
-        double rayIdStart;
-        double numRays;
-        double randomSeed;
-        double maxEvents;
-        double sequential; // sequential tracing only.
-    } inv_pushConstants;
+PushConstants inv_pushConstants;
+#else
+layout(push_constant) uniform constants {
+    double rayIdStart;
+    double numRays;
+    double randomSeed;
+    double maxEvents;
+    double sequential;  // sequential tracing only.
+    double startEventID;
+}
+inv_pushConstants;
 #endif

--- a/Intern/rayx-core/src/Shader/InvocationState.h
+++ b/Intern/rayx-core/src/Shader/InvocationState.h
@@ -22,10 +22,11 @@ struct PushConstants {  // TODO(Jannis): PushConstants is not an expressive name
     double randomSeed;
     double maxEvents;
     double sequential;
+    double startEventID;
 };
 
 struct _debug_struct {
-    dmat4 _dMat; // Can also be used as vectors or scalar
+    dmat4 _dMat;  // Can also be used as vectors or scalar
 };
 
 // we don't require forward declarations in GLSL, hence we only do them in C++:

--- a/Intern/rayx-core/src/Tracer/CpuTracer.cpp
+++ b/Intern/rayx-core/src/Tracer/CpuTracer.cpp
@@ -1,13 +1,14 @@
 
+#include "CpuTracer.h"
+
 #include <cmath>
 #include <cstring>
 
-#include "CpuTracer.h"
-#include "Shader/DynamicElements.h"
-#include "Shader/InvocationState.h"
 #include "Beamline/OpticalElement.h"
 #include "Material/Material.h"
 #include "RAY-Core.h"
+#include "Shader/DynamicElements.h"
+#include "Shader/InvocationState.h"
 
 using uint = unsigned int;
 
@@ -31,7 +32,7 @@ std::vector<Ray> CpuTracer::traceRaw(const TraceRawConfig& cfg) {
 
     // init rayData, outputData
     inv_rayData.data = rayList;
-    inv_outputData.data.resize(rayList.size() * (size_t)cfg.m_maxEvents);
+    inv_outputData.data.resize(rayList.size() * ((size_t)cfg.m_maxEvents - (size_t)cfg.m_startEventID));
 
     // init elements
     for (auto e : cfg.m_elements) {

--- a/Intern/rayx-core/src/Tracer/Tracer.h
+++ b/Intern/rayx-core/src/Tracer/Tracer.h
@@ -28,6 +28,7 @@ struct TraceRawConfig {
     double m_numRays;
     double m_randomSeed;
     double m_maxEvents;
+    double m_startEventID;
     MaterialTables m_materialTables;
     std::vector<Element> m_elements;
 };
@@ -48,7 +49,8 @@ class RAYX_API Tracer {
     // This will call traceRaw.
     // Everything happening in each traceRaw implementation should be extracted to this function instead.
     // See `BundleHistory` for information about the return value.
-    BundleHistory trace(const Beamline&, Sequential sequential, uint64_t max_batch_size, int THREAD_COUNT = 1, unsigned int maxEvents = 1);
+    BundleHistory trace(const Beamline&, Sequential sequential, uint64_t max_batch_size, int THREAD_COUNT = 1, unsigned int maxEvents = 1,
+                        int startEventID = 0);
 
     void setDevice(int deviceID);
 

--- a/Intern/rayx-core/src/Tracer/VulkanTracer.cpp
+++ b/Intern/rayx-core/src/Tracer/VulkanTracer.cpp
@@ -58,7 +58,7 @@ std::vector<Ray> VulkanTracer::traceRaw(const TraceRawConfig& cfg) {
 
     auto materialTables = cfg.m_materialTables;
     m_engine.createBufferWithData<Ray>("ray-buffer", rayList);
-    m_engine.createBuffer("output-buffer", numberOfRays * sizeof(Ray) * (size_t)cfg.m_maxEvents);
+    m_engine.createBuffer("output-buffer", numberOfRays * sizeof(Ray) * ((size_t)cfg.m_maxEvents - (size_t)cfg.m_startEventID));
     m_engine.createBufferWithData<double>("quadric-buffer", beamlineData);
     m_engine.createBuffer("xyznull-buffer", 100);
     m_engine.createBufferWithData<int>("material-index-table", materialTables.indexTable);

--- a/Intern/rayx-core/src/Writer/CSVWriter.cpp
+++ b/Intern/rayx-core/src/Writer/CSVWriter.cpp
@@ -56,7 +56,7 @@ Cell doubleToCell(double x) {
     return strToCell(s.c_str());
 }
 
-void writeCSV(const RAYX::BundleHistory& hist, const std::string& filename, const Format& format) {
+void writeCSV(const RAYX::BundleHistory& hist, const std::string& filename, const Format& format, int startEventID) {
     std::ofstream file(filename);
 
     // write header:
@@ -79,7 +79,7 @@ void writeCSV(const RAYX::BundleHistory& hist, const std::string& filename, cons
                 if (i > 0) {
                     file << DELIMITER;
                 }
-                file << doubleToCell(format[i].get_double(ray_id, event_id, event)).buf;
+                file << doubleToCell(format[i].get_double(ray_id, event_id + startEventID, event)).buf;
             }
             file << '\n';
         }

--- a/Intern/rayx-core/src/Writer/CSVWriter.h
+++ b/Intern/rayx-core/src/Writer/CSVWriter.h
@@ -8,7 +8,7 @@
 #include "Tracer/Tracer.h"
 #include "Writer/Writer.h"
 
-void RAYX_API writeCSV(const RAYX::BundleHistory&, const std::string& filename, const Format& format);
+void RAYX_API writeCSV(const RAYX::BundleHistory&, const std::string& filename, const Format& format, int startEventID = 0);
 
 // loadCSV only works for csv files created using FULL_FORMAT.
 RAYX::BundleHistory RAYX_API loadCSV(const std::string& filename);

--- a/Intern/rayx-core/src/Writer/H5Writer.cpp
+++ b/Intern/rayx-core/src/Writer/H5Writer.cpp
@@ -18,7 +18,7 @@ int count(const RAYX::BundleHistory& hist) {
     return c;
 }
 
-std::vector<double> toDoubles(const RAYX::BundleHistory& hist, const Format& format) {
+std::vector<double> toDoubles(const RAYX::BundleHistory& hist, const Format& format, int startEventID) {
     std::vector<double> output;
     output.reserve(count(hist) * format.size());
 
@@ -27,7 +27,7 @@ std::vector<double> toDoubles(const RAYX::BundleHistory& hist, const Format& for
         for (uint event_id = 0; event_id < ray_hist.size(); event_id++) {
             const RAYX::Ray& event = ray_hist[event_id];
             for (uint i = 0; i < format.size(); i++) {
-                double next = format[i].get_double(ray_id, event_id, event);
+                double next = format[i].get_double(ray_id, event_id + startEventID, event);
                 output.push_back(next);
             }
         }
@@ -35,10 +35,11 @@ std::vector<double> toDoubles(const RAYX::BundleHistory& hist, const Format& for
     return output;
 }
 
-void writeH5(const RAYX::BundleHistory& hist, const std::string& filename, const Format& format, std::vector<std::string> elementNames) {
+void writeH5(const RAYX::BundleHistory& hist, const std::string& filename, const Format& format, std::vector<std::string> elementNames,
+             int startEventID) {
     HighFive::File file(filename, HighFive::File::ReadWrite | HighFive::File::Create | HighFive::File::Truncate);
 
-    auto doubles = toDoubles(hist, format);
+    auto doubles = toDoubles(hist, format, startEventID);
 
     try {
         // write data

--- a/Intern/rayx-core/src/Writer/H5Writer.h
+++ b/Intern/rayx-core/src/Writer/H5Writer.h
@@ -9,7 +9,8 @@
 #include "Tracer/Tracer.h"
 #include "Writer/Writer.h"
 
-RAYX_API void writeH5(const RAYX::BundleHistory&, const std::string& filename, const Format& format, std::vector<std::string> elementNames);
+RAYX_API void writeH5(const RAYX::BundleHistory&, const std::string& filename, const Format& format, std::vector<std::string> elementNames,
+                      int startEventID);
 RAYX_API RAYX::BundleHistory raysFromH5(const std::string& filename, const Format& format);
 
 #endif

--- a/Intern/rayx/src/CommandParser.h
+++ b/Intern/rayx/src/CommandParser.h
@@ -41,6 +41,7 @@ class CommandParser {
         std::string m_format = defaultFormatString();  // --format
         int m_setThreads = 1;                          // -T (dipolesource)
         int m_maxEvents = -1;                          // -m (max events)
+        int m_startEventID = 0;                        // -e (start event id)
     } m_args;
 
     static inline void getVersion() {
@@ -89,5 +90,6 @@ class CommandParser {
          {OptionType::INT, "setThreads", "Number of Threads for Lightsource-Parallelization'",
           &(m_args.m_setThreads)}},  // TODO: understandable description
         {'m', {OptionType::INT, "maxEvents", "Maximum number of events per ray", &(m_args.m_maxEvents)}},
+        {'e', {OptionType::INT, "startEventID", "Start event ID", &(m_args.m_startEventID)}},
     };
 };

--- a/Intern/rayx/src/TerminalApp.h
+++ b/Intern/rayx/src/TerminalApp.h
@@ -31,7 +31,7 @@ class TerminalApp {
     /// children of that directory.
     void tracePath(const std::filesystem::path& path);
     // returns the output filename (either .csv or .h5)
-    std::string exportRays(const RAYX::BundleHistory&, std::string);
+    std::string exportRays(const RAYX::BundleHistory&, std::string, int startEventID);
     std::vector<std::string> getBeamlineOpticalElementsNames();
     std::vector<std::string> getBeamlineLightSourcesNames();
 


### PR DESCRIPTION
This feature lets the user only export events starting at startEventID. Because less data needs to be transferred it speeds up the tracing.