### PR TITLE
combine getPhysicalDevices

### DIFF
--- a/Intern/rayx-core/src/Tracer/VulkanTracer.cpp
+++ b/Intern/rayx-core/src/Tracer/VulkanTracer.cpp
@@ -15,26 +15,17 @@
 
 namespace RAYX {
 void VulkanTracer::listPhysicalDevices() {
-    auto deviceList = this->getPhysicalDevices();
+    auto deviceList = m_engine.getPhysicalDevices();
     unsigned int deviceIndex = 0;
-    std::cout << "Listing Vulkan Devices:" << std::endl;
+    RAYX_LOG << "Listing Vulkan Devices:";
     for (const auto& device : deviceList) {
         VkPhysicalDeviceProperties deviceProperties;
         vkGetPhysicalDeviceProperties(device, &deviceProperties);
 
-        std::cout << "Device: " << deviceProperties.deviceName << std::endl;
-        std::cout << "Device Index: " << deviceIndex++ << std::endl;
-        std::cout << "VendorID: " << deviceProperties.vendorID << std::endl << std::endl;
+        RAYX_LOG << "Device: " << deviceProperties.deviceName;
+        RAYX_LOG << "Device Index: " << deviceIndex++;
+        RAYX_LOG << "VendorID: " << deviceProperties.vendorID;
     }
-}
-
-std::vector<VkPhysicalDevice> VulkanTracer::getPhysicalDevices() {
-    // init, if not yet initialized.
-    if (m_engine.state() == VulkanEngine::EngineStates::PREINIT) {
-        initEngine();
-    }
-    auto deviceList = m_engine.getPhysicalDevices();
-    return deviceList;
 }
 
 std::vector<Ray> VulkanTracer::traceRaw(const TraceRawConfig& cfg) {

--- a/Intern/rayx-core/src/Tracer/VulkanTracer.h
+++ b/Intern/rayx-core/src/Tracer/VulkanTracer.h
@@ -14,7 +14,6 @@ class RAYX_API VulkanTracer : public Tracer {
     ~VulkanTracer() = default;
 
     void listPhysicalDevices();
-    std::vector<VkPhysicalDevice> getPhysicalDevices();
     std::vector<Ray> traceRaw(const TraceRawConfig&) override;
     void setPushConstants(const PushConstants*) override;
 #ifdef RAYX_DEBUG_MODE

--- a/Intern/rayx-core/src/VulkanEngine/Init/PickDevice.cpp
+++ b/Intern/rayx-core/src/VulkanEngine/Init/PickDevice.cpp
@@ -21,6 +21,9 @@ void VulkanEngine::pickDevice() {
 
 // scan for devices
 std::vector<VkPhysicalDevice> VulkanEngine::getPhysicalDevices() {
+    if (!m_Instance) {
+        createInstance();
+    }
     uint32_t deviceCount = 0;
     vkEnumeratePhysicalDevices(m_Instance, &deviceCount, nullptr);
     if (deviceCount == 0) throw std::runtime_error("failed to find GPUs with Vulkan Support!");
@@ -163,7 +166,6 @@ void VulkanEngine::createLogicalDevice() {
     deviceFeatures.shaderFloat64 = VK_TRUE;
     deviceFeatures.shaderInt64 = VK_TRUE;
     deviceFeatures.robustBufferAccess = VK_TRUE;
-
 
     VkPhysicalDeviceVulkan13Features vk13features{};
     vk13features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_3_FEATURES;

--- a/Intern/rayx-ui/src/Simulator.cpp
+++ b/Intern/rayx-ui/src/Simulator.cpp
@@ -11,8 +11,8 @@ Simulator::Simulator() {
     m_seq = RAYX::Sequential::No;
     std::vector<VkPhysicalDevice> deviceList;
     {
-        RAYX::VulkanTracer VkTracer;
-        deviceList = VkTracer.getPhysicalDevices();
+        auto engine = std::make_unique<RAYX::VulkanEngine>();
+        deviceList = engine->getPhysicalDevices();
     }
     for (const auto& device : deviceList) {
         VkPhysicalDeviceProperties deviceProperties;


### PR DESCRIPTION
Previously there were two functions:

VulkanEngine::getPhysicalDevices()
VulkanTracer::getPhysicalDevices()

The latter was for compatibility reasons. Now the functionality has been merged into VulkanEngine::getPhysicalDevices() and VulkanTracer::getPhysicalDevices() has been removed.