### PR TITLE
Many bugfixes

### DIFF
--- a/Intern/rayx-core/src/DesignElement/DesignSource.cpp
+++ b/Intern/rayx-core/src/DesignElement/DesignSource.cpp
@@ -1,29 +1,30 @@
 #include "DesignSource.h"
 
-#include "Debug/Debug.h"
-#include "Beamline/Objects/Objects.h"
 #include <filesystem>
+
+#include "Beamline/Objects/Objects.h"
+#include "Debug/Debug.h"
 namespace RAYX {
 
 std::vector<Ray> DesignSource::compile(int i) const {
     std::vector<Ray> ray;
 
-    if (getName() == "Point Source") {
+    if (getType() == "Point Source") {
         PointSource ps(*this);
         ray = ps.getRays(i);
-    } else if (getName() == "Matrix Source") {
+    } else if (getType() == "Matrix Source") {
         MatrixSource ms(*this);
-        ray = ms.getRays(i); 
-    } else if (getName() == "Dipole Source") {
+        ray = ms.getRays(i);
+    } else if (getType() == "Dipole Source") {
         DipoleSource ds(*this);
         ray = ds.getRays(i);
-    } else if (getName() == "Pixel Source") {
+    } else if (getType() == "Pixel Source") {
         PixelSource ps(*this);
         ray = ps.getRays(i);
-    } else if (getName() == "Circle Source") {
+    } else if (getType() == "Circle Source") {
         CircleSource cs(*this);
         ray = cs.getRays(i);
-    } else if (getName() == "Simple Undulator") {
+    } else if (getType() == "Simple Undulator") {
         SimpleUndulatorSource su(*this);
         ray = su.getRays(i);
     }
@@ -35,6 +36,7 @@ void DesignSource::setName(std::string s) { m_elementParameters["name"] = s; }
 void DesignSource::setType(std::string s) { m_elementParameters["type"] = s; }
 
 std::string DesignSource::getName() const { return m_elementParameters["name"].as_string(); }
+std::string DesignSource::getType() const { return m_elementParameters["type"].as_string(); }
 
 void DesignSource::setWorldPosition(glm::dvec4 p) {
     m_elementParameters["worldPosition"] = Map();
@@ -181,7 +183,9 @@ void DesignSource::setElectronEnergy(double value) { m_elementParameters["electr
 double DesignSource::getElectronEnergy() const { return m_elementParameters["electronEnergy"].as_double(); }
 
 void DesignSource::setElectronEnergyOriantation(ElectronEnergyOrientation value) { m_elementParameters["electronEnergyOriantation"] = value; }
-ElectronEnergyOrientation DesignSource::getElectronEnergyOrientation() const { return m_elementParameters["electronEnergyOriantation"].as_electronEnergyOrientation(); }
+ElectronEnergyOrientation DesignSource::getElectronEnergyOrientation() const {
+    return m_elementParameters["electronEnergyOriantation"].as_electronEnergyOrientation();
+}
 
 void DesignSource::setEnergySpread(double value) { m_elementParameters["energySpread"] = value; }
 double DesignSource::getEnergySpread() const { return m_elementParameters["energySpread"].as_double(); }

--- a/Intern/rayx-core/src/DesignElement/DesignSource.h
+++ b/Intern/rayx-core/src/DesignElement/DesignSource.h
@@ -16,6 +16,7 @@ struct RAYX_API DesignSource {
     void setName(std::string s);
     void setType(std::string s);
     std::string getName() const;
+    std::string getType() const;
 
     void setWidthDist(SourceDist value);
     SourceDist getWidthDist() const;

--- a/Intern/rayx-core/src/Writer/H5Writer.cpp
+++ b/Intern/rayx-core/src/Writer/H5Writer.cpp
@@ -125,6 +125,9 @@ RAYX::BundleHistory raysFromH5(const std::string& filename, const Format& format
         auto dims = dataset.getSpace().getDimensions();
         doubles.resize(dims[0] * dims[1]);
         dataset.read(doubles.data());
+        if (doubles.size() == 0) {
+            RAYX_ERR << "No rays found in " << filename;
+        }
         if (startEventID) {
             *startEventID = static_cast<unsigned int>(doubles[1]);
         }

--- a/Intern/rayx-ui/src/Application.cpp
+++ b/Intern/rayx-ui/src/Application.cpp
@@ -61,6 +61,7 @@ void Application::init() {
 
     std::string rmlPathCli = m_CommandParser.m_args.m_providedFile;
     UIRayInfo rayInfo{
+        .raysLoaded = false,     //
         .displayRays = true,     //
         .raysChanged = false,    //
         .cacheChanged = false,   //

--- a/Intern/rayx-ui/src/Application.cpp
+++ b/Intern/rayx-ui/src/Application.cpp
@@ -209,7 +209,12 @@ void Application::run() {
                     if (buildRayCacheFuture.wait_for(std::chrono::seconds(0)) == std::future_status::ready) {
                         m_Scene->buildRaysRObject(*m_Beamline, m_UIParams.rayInfo, textureSetLayout, m_TexturePool);
                         m_UIParams.rayInfo.raysLoaded = true;
-                        m_State = State::PrepareElements;
+                        if (m_buildElementsNeeded) {
+                            m_State = State::PrepareElements;
+                        } else {
+                            m_State = State::Running;
+                            m_buildElementsNeeded = true;
+                        }
                     }
                     break;
                 case State::PrepareElements:
@@ -239,6 +244,7 @@ void Application::run() {
             if (m_UIParams.rayInfo.raysChanged) {
                 m_State = State::BuildingRays;
                 m_UIParams.rayInfo.raysChanged = false;
+                m_buildElementsNeeded = false;
             }
 
             // Update UBO

--- a/Intern/rayx-ui/src/Application.h
+++ b/Intern/rayx-ui/src/Application.h
@@ -75,6 +75,7 @@ class Application {
     std::filesystem::path m_RMLPath;             ///< Path to the RML file
     std::unique_ptr<RAYX::Beamline> m_Beamline;  ///< Beamline
     RAYX::BundleHistory m_rays;                  ///< Ray cache
+    bool m_buildElementsNeeded = true;
 
     void init();
 

--- a/Intern/rayx-ui/src/Camera.cpp
+++ b/Intern/rayx-ui/src/Camera.cpp
@@ -162,11 +162,13 @@ std::string SerializeCameraController(const CameraController& cam) {
 // Deserialize the CameraController from a string
 void DeserializeCameraController(CameraController& cam, const std::string& data) {
     std::istringstream ss(data);
-    glm::vec3 pos = cam.getPosition();
-    glm::vec3 dir = cam.getDirection();
+    glm::vec3 pos;
+    glm::vec3 dir;
 
     ss >> pos.x >> pos.y >> pos.z;
     ss >> dir.x >> dir.y >> dir.z;
+    cam.setPosition(pos);
+    cam.setDirection(dir);
 }
 
 // Save to file

--- a/Intern/rayx-ui/src/Camera.h
+++ b/Intern/rayx-ui/src/Camera.h
@@ -34,6 +34,8 @@ class CameraController {
     void setCameraMode(CameraMode mode);
     glm::vec3 getPosition() const { return m_position; }
     glm::vec3 getDirection() const { return m_direction; }
+    void setPosition(const glm::vec3& pos) { m_position = pos; }
+    void setDirection(const glm::vec3& dir) { m_direction = dir; }
 
   private:
     glm::vec3 m_position;

--- a/Intern/rayx-ui/src/Scene.cpp
+++ b/Intern/rayx-ui/src/Scene.cpp
@@ -130,7 +130,7 @@ void Scene::buildRObjectsFromInput(std::vector<RenderObjectInput>&& inputs, std:
     assert(setLayout != nullptr && "Descriptor set layout is null");
     assert(descriptorPool != nullptr && "Descriptor pool is null");
     RAYX_PROFILE_FUNCTION_STDOUT();
-
+    m_ElementRObjects.clear();
     for (const auto& input : inputs) {
         std::vector<VertexVariant> convertedVertices(input.vertices.begin(), input.vertices.end());
         if (input.textureInput.has_value()) {

--- a/Intern/rayx-ui/src/UserInterface/BeamlineOutliner.cpp
+++ b/Intern/rayx-ui/src/UserInterface/BeamlineOutliner.cpp
@@ -119,14 +119,16 @@ void BeamlineOutliner::showBeamlineOutlineWindow(UIParameters& uiParams, std::ve
                                                  std::vector<glm::dvec3>& rSourcePositions) {
     ImGui::Begin("Beamline Outline");
 
-    if (uiParams.rmlReady) {
+    if (uiParams.rmlPath.empty()) {
+        ImGui::Text("Choose a file to display the beamline outline.");
+    } else if (uiParams.rmlPath != m_currentRML) {
         // Create and render new Tree
         m_lightSourceIndex = 0;
         m_opticalElementIndex = 0;
         renderImGuiTreeFromRML(uiParams.rmlPath, uiParams.camController, elements, rSourcePositions);
+        m_currentRML = uiParams.rmlPath;
     } else if (m_pTreeRoot == nullptr) {
-        // Do nothing
-        ImGui::Text("Choose a file to display the beamline outline.");
+        RAYX_ERR << "Error: Tree root is null.";
     } else {
         // Render same Tree
         renderImGuiTree(*m_pTreeRoot, uiParams.camController, elements, rSourcePositions);

--- a/Intern/rayx-ui/src/UserInterface/BeamlineOutliner.h
+++ b/Intern/rayx-ui/src/UserInterface/BeamlineOutliner.h
@@ -31,6 +31,7 @@ class BeamlineOutliner {
 
     int m_lightSourceIndex = 0;
     int m_opticalElementIndex = 0;
+    std::filesystem::path m_currentRML;
 
     void renderImGuiTree(const TreeNode& treeNode, CameraController& camController, std::vector<RAYX::DesignElement>& rObjects,
                          std::vector<glm::dvec3>& rSourcePositions) const;

--- a/Intern/rayx-ui/src/UserInterface/Settings.h
+++ b/Intern/rayx-ui/src/UserInterface/Settings.h
@@ -88,12 +88,12 @@ struct UIParameters {
             RAYX_ERR << "RML file does not exist: " << path.string();
         }
 #ifdef NO_H5
-        if (!std::filesystem::exists(path.string().substr(0, path.string().size() - 4) + ".csv")) {
-            RAYX_ERR << "Matching CSV file for" << path.string() << "does not exist";
+        if (std::filesystem::exists(path.string().substr(0, path.string().size() - 4) + ".csv")) {
+            h5Ready = true;
         }
 #else
-        if (!std::filesystem::exists(path.string().substr(0, path.string().size() - 4) + ".h5")) {
-            RAYX_ERR << "Matching H5 file for" << path.string() << "does not exist";
+        if (std::filesystem::exists(path.string().substr(0, path.string().size() - 4) + ".h5")) {
+            h5Ready = true;
         }
 #endif
         rmlPath = path;

--- a/Intern/rayx-ui/src/UserInterface/UIHandler.cpp
+++ b/Intern/rayx-ui/src/UserInterface/UIHandler.cpp
@@ -323,6 +323,13 @@ void UIHandler::setupUI(UIParameters& uiParams, std::vector<RAYX::DesignElement>
     showHotkeysWindow();
     ImGui::End();
 
+    // setting focus to the beamline outline window
+    static bool first_time = true;
+    if (first_time) {
+        first_time = false;
+        ImGui::SetWindowFocus("Beamline Outline");
+    }
+
     ImGui::PopFont();
 }
 
@@ -363,7 +370,7 @@ void UIHandler::showSceneEditorWindow(UIParameters& uiParams) {
             if (m_showRMLNotExistPopup) {
                 uiParams.rmlReady = false;
             } else {
-                uiParams.h5Ready = !uiParams.showH5NotExistPopup;
+                uiParams.h5Ready = !uiParams.showH5NotExistPopup && m_loadh5withRML;
                 uiParams.rmlReady = true;
                 uiParams.rmlPath = outPath;
             }
@@ -417,6 +424,9 @@ void UIHandler::showSettingsWindow() {
     ImGui::Begin("Settings");
 
     ImGui::SliderFloat("Scale", &m_scale, 0.1f, 4.0f, "%.1f", ImGuiSliderFlags_AlwaysClamp);
+
+    // checkbox
+    ImGui::Checkbox("Load h5 with RML", &m_loadh5withRML);
 
     ImGui::End();
 }

--- a/Intern/rayx-ui/src/UserInterface/UIHandler.cpp
+++ b/Intern/rayx-ui/src/UserInterface/UIHandler.cpp
@@ -385,7 +385,7 @@ void UIHandler::showSceneEditorWindow(UIParameters& uiParams) {
         if (ImGui::Button("Trace current file")) {
             uiParams.showH5NotExistPopup = false;
             m_showRMLNotExistPopup = false;
-            uiParams.rmlReady = true;
+            // uiParams.rmlReady = true;
             uiParams.runSimulation = true;
         }
     } else {

--- a/Intern/rayx-ui/src/UserInterface/UIHandler.cpp
+++ b/Intern/rayx-ui/src/UserInterface/UIHandler.cpp
@@ -223,7 +223,7 @@ void UIHandler::beginUIRender() {
  * @param uiParams
  * @param rObjects
  */
-void UIHandler::setupUI(UIParameters& uiParams, std::vector<RAYX::DesignElement>& elemets, std::vector<glm::dvec3>& rSourcePositions) {
+void UIHandler::setupUI(UIParameters& uiParams, std::vector<RAYX::DesignElement>& elements, std::vector<glm::dvec3>& rSourcePositions) {
     ImFont* currentFont;
     float adjustedScale;
     if (m_oldScale != m_scale) {
@@ -319,7 +319,7 @@ void UIHandler::setupUI(UIParameters& uiParams, std::vector<RAYX::DesignElement>
     showMissingFilePopupWindow(uiParams);
     showSimulationSettingsPopupWindow(uiParams);
     showSettingsWindow();
-    m_BeamlineOutliner.showBeamlineOutlineWindow(uiParams, elemets, rSourcePositions);
+    m_BeamlineOutliner.showBeamlineOutlineWindow(uiParams, elements, rSourcePositions);
     showHotkeysWindow();
     ImGui::End();
 

--- a/Intern/rayx-ui/src/UserInterface/UIHandler.cpp
+++ b/Intern/rayx-ui/src/UserInterface/UIHandler.cpp
@@ -385,7 +385,6 @@ void UIHandler::showSceneEditorWindow(UIParameters& uiParams) {
         if (ImGui::Button("Trace current file")) {
             uiParams.showH5NotExistPopup = false;
             m_showRMLNotExistPopup = false;
-            // uiParams.rmlReady = true;
             uiParams.runSimulation = true;
         }
     } else {

--- a/Intern/rayx-ui/src/UserInterface/UIHandler.h
+++ b/Intern/rayx-ui/src/UserInterface/UIHandler.h
@@ -41,6 +41,7 @@ class UIHandler {
     std::vector<ImFont*> m_fonts;
 
     bool m_showRMLNotExistPopup = false;
+    bool m_loadh5withRML = true;
 
     VkRenderPass m_RenderPass;
     VkDescriptorPool m_DescriptorPool;

--- a/Intern/rayx-ui/src/main.cpp
+++ b/Intern/rayx-ui/src/main.cpp
@@ -1,9 +1,14 @@
 #include <nfd.h>
 
+#include <clocale>
+
 #include "Application.h"
 
 int main(int argc, char** argv) {
     NFD_Init();  // Initialize Native File Dialog
+
+    // Set locale to C to avoid issues with scanf
+    std::setlocale(LC_NUMERIC, "C");
 
     Application app(1920, 1080, "RAYX-UI", argc, argv);
 


### PR DESCRIPTION
- Decimal separator is now set independently from the system decimal separator
    - RML and h5 files are now loaded correctly
- Beamline Outline is now loaded correctly
- Beamline Outline is now selected as default (instead of hotkeys)
- Camera can now be loaded again
- Checkbox to load RML without h5 even if h5 exists
- Removed unnecessary RML reload
- fixed textures by removing duplicate object load
- Removed unnecessary element rebuild after changing ray amount