### PR TITLE
replace glm include file with cmake compile definitions

### DIFF
--- a/Intern/rayx-core/CMakeLists.txt
+++ b/Intern/rayx-core/CMakeLists.txt
@@ -152,6 +152,9 @@ target_compile_definitions(${PROJECT_NAME}
     RAYX_PROJECT_DIR="${CMAKE_SOURCE_DIR}"
     $<$<CONFIG:Debug>:RAYX_DEBUG_MODE>
     $<$<CONFIG:RelWithDebInfo>:RAYX_DEBUG_MODE>
+    PUBLIC GLM_ENABLE_EXPERIMENTAL
+    PUBLIC GLM_FORCE_UNRESTRICTED_GENTYPE
+    PUBLIC GLM_FORCE_XYZW_ONLY
 )
 
 # Inform about the cuda and hip config of alpaka

--- a/Intern/rayx-core/src/Angle.h
+++ b/Intern/rayx-core/src/Angle.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <glm.h>
+#include <glm.hpp>
 
 #include <array>
 #include <vector>

--- a/Intern/rayx-core/src/Beamline/LightSource.h
+++ b/Intern/rayx-core/src/Beamline/LightSource.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <glm.h>
+#include <glm.hpp>
 
 #include <array>
 #include <string>

--- a/Intern/rayx-core/src/Element/Element.h
+++ b/Intern/rayx-core/src/Element/Element.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <glm.h>
+#include <glm.hpp>
 
 #include <optional>
 

--- a/Intern/rayx-core/src/Rml/xml.h
+++ b/Intern/rayx-core/src/Rml/xml.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <glm.h>
+#include <glm.hpp>
 
 #include <array>
 #include <filesystem>

--- a/Intern/rayx-core/src/Shader/Collision.h
+++ b/Intern/rayx-core/src/Shader/Collision.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <glm.h>
+#include <glm.hpp>
 
 #include "Core.h"
 #include "Element/Cutout.h"

--- a/Intern/rayx-core/src/Shader/Complex.h
+++ b/Intern/rayx-core/src/Shader/Complex.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <glm.h>
+#include <glm.hpp>
 
 #include "Core.h"
 

--- a/Intern/rayx-core/src/Shader/CutoutFns.h
+++ b/Intern/rayx-core/src/Shader/CutoutFns.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <glm.h>
+#include <glm.hpp>
 
 #include "Element/Cutout.h"
 

--- a/Intern/rayx-core/src/Shader/Efficiency.h
+++ b/Intern/rayx-core/src/Shader/Efficiency.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <glm.h>
+#include <glm.hpp>
 
 #include "Complex.h"
 #include "Constants.h"

--- a/Intern/rayx-core/src/Shader/Rand.cpp
+++ b/Intern/rayx-core/src/Shader/Rand.cpp
@@ -1,6 +1,6 @@
 #include "Rand.h"
 
-#include <glm.h>
+#include <glm.hpp>
 
 #include "Constants.h"
 

--- a/Intern/rayx-core/src/Shader/Ray.h
+++ b/Intern/rayx-core/src/Shader/Ray.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <glm.h>
+#include <glm.hpp>
 
 #include "Core.h"
 #include "Efficiency.h"

--- a/Intern/rayx-core/src/Shader/SphericalCoords.h
+++ b/Intern/rayx-core/src/Shader/SphericalCoords.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <glm.h>
+#include <glm.hpp>
 
 #include "Core.h"
 

--- a/Intern/rayx-core/src/glm.h
+++ b/Intern/rayx-core/src/glm.h
@@ -1,6 +1,0 @@
-#pragma once
-
-#define GLM_ENABLE_EXPERIMENTAL
-#define GLM_FORCE_UNRESTRICTED_GENTYPE
-#define GLM_FORCE_XYZW_ONLY
-#include <glm.hpp>

--- a/Intern/rayx-ui/src/Camera.h
+++ b/Intern/rayx-ui/src/Camera.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <glm.h>
+#include <glm.hpp>
 
 #include <string>
 

--- a/Intern/rayx-ui/src/Colors.h
+++ b/Intern/rayx-ui/src/Colors.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <glm.h>
+#include <glm.hpp>
 
 static constexpr glm::vec4 RED = {1.0f, 0.0f, 0.0f, 1.0f};
 static constexpr glm::vec4 ORANGE = {1.0f, 0.5f, 0.0f, 1.0f};

--- a/Intern/rayx-ui/src/Plotting.cpp
+++ b/Intern/rayx-ui/src/Plotting.cpp
@@ -3,7 +3,7 @@
 #include "Debug/Instrumentor.h"
 
 #define STB_IMAGE_WRITE_IMPLEMENTATION
-#include <glm.h>
+#include <glm.hpp>
 #include <stb_image_write.h>
 
 #include <array>

--- a/Intern/rayx-ui/src/RenderObject.h
+++ b/Intern/rayx-ui/src/RenderObject.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <glm.h>
+#include <glm.hpp>
 
 #include <vector>
 

--- a/Intern/rayx-ui/src/Vertex.h
+++ b/Intern/rayx-ui/src/Vertex.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <glm.h>
+#include <glm.hpp>
 #include <vulkan/vulkan.h>
 
 #include <array>


### PR DESCRIPTION
we use a proxy include file that adds compiler definitions before including glm. this is prone to errors, because one can accidentally include glm directly, which for other code sections, potentially hides the definitions from glm.

now we do the definitions in cmake with PUBLIC attribute, to the bring effect to rayx-ui aswell