### PR TITLE
Make OpenMP optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,8 @@ set(CMAKE_CUDA_STANDARD_REQUIRED ON)
 option(WERROR "add -Werror option" "NO") # inactive per default
 option(RAYX_ENABLE_CUDA "This option enables the search for CUDA. Project will be compiled without cuda if not found." ON)
 option(RAYX_REQUIRE_CUDA "If option 'RAYX_ENABLE_CUDA' is ON, this option will add the requirement that cuda must be found." OFF)
+option(RAYX_ENABLE_OPENMP "This option enables the search for OPENMP. Project will be compiled without openmp if not found." ON)
+option(RAYX_REQUIRE_OPENMP "If option 'RAYX_ENABLE_OPENMP' is ON, this option will add the requirement that openmp must be found." OFF)
 option(RAYX_STATIC_LIB "This option builds 'rayx-core' as a static library." OFF)
 
 # ------------------

--- a/Extern/CMakeLists.txt
+++ b/Extern/CMakeLists.txt
@@ -21,9 +21,23 @@ add_subdirectory(CLI11)
 
 # -------------------
 
-# ---- Check for CUDA and configure Alpaka ----
-set(alpaka_ACC_CPU_B_OMP2_T_SEQ_ENABLE ON CACHE BOOL "" FORCE)
+# ---- Check for CUDA and OPENMP support and configure Alpaka ----
 set(alpaka_ACC_CPU_B_SEQ_T_SEQ_ENABLE ON CACHE BOOL "" FORCE)
+
+if(RAYX_ENABLE_OPENMP)
+    find_package(OpenMP COMPONENTS CXX)
+    if(OpenMP_CXX_FOUND)
+       set(alpaka_ACC_CPU_B_OMP2_T_SEQ_ENABLE ON CACHE BOOL "" FORCE)
+    else()
+        if(RAYX_REQUIRE_OPENMP)
+            message(FATAL_ERROR "No OpenMP CXX compiler found by CMake, but 'RAYX_REQUIRE_OPENMP is set.'")
+        else()
+            message(WARNING "No OpenMP CXX compiler found by CMake. OpenMP support will be disabled.'")
+        endif()
+    endif()
+else() # setting could be cached so force it off
+    set(alpaka_ACC_CPU_B_OMP2_T_SEQ_ENABLE OFF CACHE BOOL "" FORCE)
+endif()
 
 if(RAYX_ENABLE_CUDA)
     check_language(CUDA)

--- a/compile.sh
+++ b/compile.sh
@@ -9,6 +9,7 @@ echo
 
 mode=Debug
 enable_cuda=0
+enable_openmp=1
 
 for var in "$@"
 do
@@ -16,12 +17,15 @@ do
         mode=Release
     elif [[ "$var" == "--cuda" ]]; then
         enable_cuda=1
+    elif [[ "$var" == "--no-openmp" ]]; then
+        enable_openmp=0
     elif [[ "$var" == "--help" ]]; then
         echo "Usage:"
         echo " ./compile.sh [OPTIONS]..."
         echo "Options:"
         echo "--release 'Build in Release mode. Otherwise build in Debug mode'"
         echo "--cuda 'Build with Cuda for tracing on GPU. Otherwise build without Cuda'"
+        echo "--no-openmp 'Force Build without OpenMP for multithreaded tracing on the CPU.'"
         exit
     else
         echo "Error: Unknown option '$var'"
@@ -36,6 +40,12 @@ if [ "$enable_cuda" -eq "1" ]; then
     conf="$conf -D RAYX_ENABLE_CUDA=ON -DRAYX_REQUIRE_CUDA=ON"
 else
     conf="$conf -D RAYX_ENABLE_CUDA=OFF"
+fi
+
+if [ "$enable_openmp" -eq "0" ]; then
+    conf="$conf -D RAYX_ENABLE_OPENMP=OFF"
+else
+    conf="$conf -D RAYX_ENABLE_OPENMP=ON"
 fi
 
 echo Updating git submodules ...


### PR DESCRIPTION
Previously OpenMP was necessary to build the project. With this, a missing OpenMP Installation should no longer fail the build. 
This might be useful if a faster Accelerator like CUDA is available.

The behaviour be configured with CMAKE flags (analog to CUDA):
RAYX_ENABLE_OPENMP builds with OpenMP support if available (Default ON).
RAYX_REQUIRE_OPENMP makes it required (Default: OFF).

Rayx should already fall back to single threaded sequential execution, if the corresponding Alpaka flags for faster Accelerators are disabled (seePlatform.h).