### PR TITLE
enable use of rayx repository as submodule

### DIFF
--- a/.github/workflows/testWindows.yml
+++ b/.github/workflows/testWindows.yml
@@ -61,7 +61,7 @@ jobs:
           INPUT_CUDA_VERSION: 12.5.1
 
       - name: Configure CMake
-        run: cmake -B ${{github.workspace}}/build -DWERROR=YES -DRAYX_REQUIRE_CUDA=ON
+        run: cmake -B ${{github.workspace}}/build -DWERROR=YES -DRAYX_REQUIRE_CUDA=ON -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
 
       - name: Build
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,20 @@ option(RAYX_STATIC_LIB "This option builds 'rayx-core' as a static library." OFF
 
 # ------------------
 
+# ---- Defaults ----
+
+if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE "Debug")
+endif()
+
+# ------------------
+
+# ---- RAYX directory ----
+
+set(RAYX_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+
+# ------------------------
+
 # ---- Code Coverage ----
 set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/Extern/cmake)
 # ------------------

--- a/Intern/rayx-core/CMakeLists.txt
+++ b/Intern/rayx-core/CMakeLists.txt
@@ -188,7 +188,7 @@ target_link_libraries(${PROJECT_NAME} PUBLIC alpaka::alpaka)
 
 # ---- Data ----
 # Define the source and destination paths
-set(DATA_SRC_DIR "${CMAKE_SOURCE_DIR}/Data")
+set(DATA_SRC_DIR "${RAYX_SOURCE_DIR}/Data")
 # Set the destination directory for the Data directory based on the build type
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
     set(DATA_DST_DIR "${CMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG}/Data")
@@ -207,7 +207,7 @@ add_custom_command(
 
 # ---- Scripts ----
 # Define the source and destination paths
-set(SCRIPT_SRC_DIR "${CMAKE_SOURCE_DIR}/Scripts/plot.py")
+set(SCRIPT_SRC_DIR "${RAYX_SOURCE_DIR}/Scripts/plot.py")
 # Set the destination directory for the Scripts directory based on the build type
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
     set(SCRIPT_DST_DIR "${CMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG}/Scripts/plot.py")


### PR DESCRIPTION
The usage of `CMAKE_SOURCE_DIR` created problems while using rayx as submodule.
This has been fixed by introducing the new variable `RAYX_SOURCE_DIR`