### PR TITLE
feat(cli): add -o/--output option to specify export output path

### DIFF
--- a/Intern/rayx/src/CommandParser.h
+++ b/Intern/rayx/src/CommandParser.h
@@ -34,6 +34,7 @@ class CommandParser {
         bool m_benchmark = false;                      // -b (Benchmark)
         bool m_version = false;                        // -v (Version)
         std::string m_providedFile = "";               // -i (Input)
+        std::string m_outPath = "";                    // -o (Output)
         bool m_isFixSeed = false;                      // -f (Fixed Seed)
         int m_seed = -1;                               // -s (Provided Seed)
         int m_BatchSize = 0;                           // -b (Vk batch size )
@@ -79,6 +80,7 @@ class CommandParser {
         {'d', {OptionType::INT, "device", "Pick device via Device ID", &(m_args.m_deviceID)}},
         {'l', {OptionType::BOOL, "list", "List available devices", &(m_args.m_listDevices)}},
         {'i', {OptionType::STRING, "input", "Input RML File or Directory.", &(m_args.m_providedFile)}},
+        {'o', {OptionType::STRING, "output", "Output path or filename", &(m_args.m_outPath)}},
         {'v', {OptionType::BOOL, "version", "", &(m_args.m_version)}},
         {'f', {OptionType::BOOL, "", "Fix the seed to RAYX::FIXED_SEED (Uses default)", &(m_args.m_isFixSeed)}},
         {'s', {OptionType::INT, "seed", "Provided user seed", &(m_args.m_seed)}},

--- a/Intern/rayx/src/TerminalApp.h
+++ b/Intern/rayx/src/TerminalApp.h
@@ -31,7 +31,7 @@ class TerminalApp {
     /// children of that directory.
     void tracePath(const std::filesystem::path& path);
     // returns the output filename (either .csv or .h5)
-    std::string exportRays(const RAYX::BundleHistory&, std::string);
+    std::filesystem::path exportRays(const RAYX::BundleHistory&, bool isCSV, const std::filesystem::path&, const Format& fmt);
     std::vector<std::string> getBeamlineOpticalElementsNames();
     std::vector<std::string> getBeamlineLightSourcesNames();
 


### PR DESCRIPTION
Sure! Here's a filled-out version of your Pull Request Template for the new `-o` / `--out` CLI argument feature:

---

## Pull Request Template

**Summary:**
This PR adds support for an `-o` / `--out` command-line argument that allows users to specify a custom output path for exporting traced rays.

Optional notes for reviewer:
Please check the path handling. Are the edge cases covered? Because of the upcoming changes to the documentation I would skip updating the wiki here. It is at least documented via `rayx --help`. Also do we have any tests for the CLI? Do we need them?

---

### ✅ Pre-Merge Checklist

⚠️ Reminder: By requesting a review, you confirm this PR is complete from your side. Once approved, it may be merged by someone else. Both developers and reviewers must ensure the PR is truly ready for merge when all checks are green.

Please complete each item before requesting a review.

* [x] Code follows the project's coding standards
* [ ] Unit tests for new functionality are added and pass
* [x] All existing tests pass
* [x] Documentation is updated including:
  * [x] Doxygen comments for any new rayx-core API functions
  * [x] Helpful inline comments where needed for clarity
* [x] Commits:
  * [x] Use clear and readable commit messages
  * [x] Squash and rebase onto `master` if individual commits don’t add value
  * [x] Ensure linear commit history (required by `master`)
