### PR TITLE
make h5 complex compatible with python complex

### DIFF
--- a/Intern/rayx-core/src/Writer/H5Writer.cpp
+++ b/Intern/rayx-core/src/Writer/H5Writer.cpp
@@ -24,8 +24,8 @@ inline HighFive::DataType highfive_create_type_EventType() {
 
 inline HighFive::DataType highfive_create_type_ElectricField() {
     return HighFive::CompoundType({
-        {"real", HighFive::AtomicType<double>(), 0},
-        {"imag", HighFive::AtomicType<double>(), sizeof(double)},
+        {"r", HighFive::AtomicType<double>(), 0},
+        {"i", HighFive::AtomicType<double>(), sizeof(double)},
     });
 }
 }  // unnamed namespace


### PR DESCRIPTION
## Type of Change

- [x] Bug fix (non breaking change, fixing an issue)
- [ ] New feature
- [x] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Documentation / Wiki update

## Description

written complex numbers from rays are now compatible with reading h5 from python and interpreting as complex numbers.

