### PR TITLE
switch project source dir to rayx source dir in cmake files 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,7 @@ set(RAYX_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 # ------------------------
 
 # ---- Code Coverage ----
-set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/Extern/cmake)
+set(CMAKE_MODULE_PATH ${RAYX_SOURCE_DIR}/Extern/cmake)
 # ------------------
 
 # ---- CPack ----

--- a/Intern/rayx-core/CMakeLists.txt
+++ b/Intern/rayx-core/CMakeLists.txt
@@ -254,11 +254,11 @@ elseif(WIN32)
         ARCHIVE DESTINATION .
     )
 endif()
-install(DIRECTORY ${CMAKE_SOURCE_DIR}/Data/nff
+install(DIRECTORY ${RAYX_SOURCE_DIR}/Data/nff
         DESTINATION ${INSTALL_DATA_DIR}/Data)
-install(DIRECTORY ${CMAKE_SOURCE_DIR}/Data/PALIK
+install(DIRECTORY ${RAYX_SOURCE_DIR}/Data/PALIK
         DESTINATION ${INSTALL_DATA_DIR}/Data)
-install(DIRECTORY ${CMAKE_SOURCE_DIR}/Scripts
+install(DIRECTORY ${RAYX_SOURCE_DIR}/Scripts
         DESTINATION ${INSTALL_DATA_DIR})
 include(InstallRequiredSystemLibraries)
 include(CPack)


### PR DESCRIPTION
## Type of Change

- [x] Bug fix (non breaking change, fixing an issue)

## Description

CMake searches for data files in wrong folder during compilation of rayx as a submodule. 
This is fixed now. 

----------

## ✅ Pre-Merge Checklist

> [!IMPORTANT]
> By requesting a review, you confirm this PR is complete from your side. Once approved, it may be merged by someone else. Both developers and reviewers must ensure the PR is truly ready for merge when all checks are green.

Please complete each item before requesting a review.

- [x] Code follows the project's coding standards
- [x] Commits:
    - Use clear and readable commit messages (e.g. [Conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary))
    - Squash and rebase onto `master` if individual commits don’t add value
    - Ensure linear commit history (required by `master`)
