### PR TITLE
fix cutout getter

### DIFF
--- a/Intern/rayx-core/src/Design/DesignElement.cpp
+++ b/Intern/rayx-core/src/Design/DesignElement.cpp
@@ -195,6 +195,8 @@ Cutout DesignElement::getCutout() const {
             .m_widthB = m_elementParameters["CutoutWidthB"].as_double(),
             .m_length = m_elementParameters["CutoutLength"].as_double(),
         };
+    } else if (type == CutoutType::Unlimited) {
+        return Cutout::Unlimited{};
     } else {
         RAYX_EXIT << "DesignElement::getCutout: Unknown CutoutType: " << static_cast<int>(type) << "!";
         return Cutout::Unlimited{};
@@ -203,7 +205,7 @@ Cutout DesignElement::getCutout() const {
 
 Cutout DesignElement::getGlobalCutout() const { return Cutout::Unlimited{}; }
 
-void DesignElement::setVLSParameters(const std::array<double, 6>& values) {
+void DesignElement::setVLSParameters(std::array<double, 6> values) {
     m_elementParameters["vlsParams"] = Map();
 
     m_elementParameters["vlsParams"]["vlsParameterB2"] = values[0];
@@ -467,7 +469,7 @@ BehaviourType DesignElement::getBehaviourType() const { return m_elementParamete
 void DesignElement::setCrystalType(CrystalType value) { m_elementParameters["crystalType"] = value; }
 CrystalType DesignElement::getCrystalType() const { return m_elementParameters["crystalType"].as_crystalType(); }
 
-void DesignElement::setCrystalMaterial(const std::string& value) { m_elementParameters["crystalMaterial"] = value; }
+void DesignElement::setCrystalMaterial(std::string value) { m_elementParameters["crystalMaterial"] = value; }
 std::string DesignElement::getCrystalMaterial() const { return m_elementParameters["crystalMaterial"].as_string(); }
 
 void DesignElement::setStructureFactorReF0(double value) { m_elementParameters["structureFactorReF0"] = value; }

--- a/Intern/rayx-core/src/Design/DesignElement.h
+++ b/Intern/rayx-core/src/Design/DesignElement.h
@@ -52,7 +52,7 @@ class RAYX_API DesignElement : public BeamlineNode {
     Cutout getCutout() const;
     Cutout getGlobalCutout() const;
 
-    void setVLSParameters(const std::array<double, 6>& values);
+    void setVLSParameters(std::array<double, 6> values);
     std::array<double, 6> getVLSParameters() const;
 
     void setExpertsOptics(Surface value);
@@ -204,11 +204,8 @@ class RAYX_API DesignElement : public BeamlineNode {
     void setCrystalType(CrystalType value);
     CrystalType getCrystalType() const;
 
-    void setCrystalMaterial(const std::string& value);
+    void setCrystalMaterial(std::string value);
     std::string getCrystalMaterial() const;
-
-    void setOffsetAngleType(OffsetAngleType value);
-    OffsetAngleType getOffsetAngleType() const;
 
     void setOffsetAngle(Rad value);
     Rad getOffsetAngle() const;


### PR DESCRIPTION
## Type of Change

- [x] Bug fix (non breaking change, fixing an issue)

## Description

- `DesignElement::getCutout()` failed with `CutoutType::Unlimited`. This was fixed.
- Converted a few  setters to call by value
