### PR TITLE
Fix windows CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "main"
+    open-pull-requests-limit: 10
+    # open one grouped pr instead of one per dependency
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/releaseDeploy.yml
+++ b/.github/workflows/releaseDeploy.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: windows-2025
+          - os: windows-2022
             build-type: Release
           - os: ubuntu-24.04
             build-type: Release
@@ -35,19 +35,15 @@ jobs:
           vulkan-use-cache: true
 
       - name: Install dependencies (Windows)
-        if: matrix.os == 'windows-2025'
+        if: matrix.os == 'windows-2022'
         run: |
           vcpkg install hdf5 --triplet x64-windows
           vcpkg integrate install
           echo "$env:VCPKG_INSTALLATION_ROOT\installed\x64-windows\bin" >> $GITHUB_PATH
         shell: powershell
 
-      - name: Install NSIS (Windows)
-        if: matrix.os == 'windows-2025'
-        run: choco install nsis -y
-
       - name: Setup CUDA Toolkit
-        if: matrix.os == 'windows-2025'
+        if: matrix.os == 'windows-2022'
         id: cuda-toolkit
         shell: pwsh
         run: .\Scripts\setup-cuda.ps1
@@ -55,7 +51,7 @@ jobs:
             INPUT_CUDA_VERSION: 12.9.1
 
       - name: Configure CMake (Windows)
-        if: matrix.os == 'windows-2025'
+        if: matrix.os == 'windows-2022'
         run: cmake -B ${{github.workspace}}/build -DRAYX_WERROR=ON -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} -DRAYX_REQUIRE_CUDA=ON -DRAYX_REQUIRE_OPENMP=ON -DRAYX_REQUIRE_CUDA=ON -DCMAKE_INSTALL_PREFIX=${{github.workspace}}/install
 
       # Linux-specific build steps
@@ -87,12 +83,12 @@ jobs:
 
       # Generate Windows artifacts (ZIP and NSIS installer)
       - name: CPack (Windows - ZIP)
-        if: matrix.os == 'windows-2025'
+        if: matrix.os == 'windows-2022'
         working-directory: ${{github.workspace}}/build
         run: cpack -G ZIP
 
       - name: CPack (Windows - NSIS Installer)
-        if: matrix.os == 'windows-2025'
+        if: matrix.os == 'windows-2022'
         working-directory: ${{github.workspace}}/build
         run: cpack -G NSIS
 
@@ -114,7 +110,7 @@ jobs:
 
       # Upload artifacts (Windows)
       - name: Upload build artifacts (Windows)
-        if: matrix.os == 'windows-2025'
+        if: matrix.os == 'windows-2022'
         uses: actions/upload-artifact@v4
         with:
           name: windows-artifacts

--- a/.github/workflows/testWindows.yml
+++ b/.github/workflows/testWindows.yml
@@ -31,20 +31,11 @@ jobs:
         shell: powershell
 
       - name: Prepare Vulkan SDK
-        uses: humbletim/install-vulkan-sdk@c2aa128094d42ba02959a660f03e0a4e012192f9
+        uses: humbletim/setup-vulkan-sdk@v1.2.1
         with:
-          version: 1.3.275.0
-          cache: true
-
-      - name: Download glslangValidator
-        run: curl -L -o glslang.zip https://github.com/KhronosGroup/glslang/releases/download/main-tot/glslang-master-windows-Release.zip
-
-      - name: Extract glslangValidator
-        shell: powershell
-        run: Expand-Archive -Path glslang.zip -DestinationPath ${{github.workspace}}/glslang
-
-      - name: Add glslangValidator to PATH
-        run: echo "${{github.workspace}}/glslang/bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          vulkan-query-version: 1.4.304.1
+          vulkan-components: Vulkan-Headers, Vulkan-Loader, SPIRV-Tools, Glslang
+          vulkan-use-cache: true
 
       - name: Setup CUDA Toolkit
         id: cuda-toolkit

--- a/.github/workflows/testWindows.yml
+++ b/.github/workflows/testWindows.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
-    runs-on: windows-2025
+    runs-on: windows-2022
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Type of Change

- [x] Bug fix (non-breaking change, fixing an issue)
- [x] New feature: Dependabot for GitHub actions
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Documentation / Wiki update

## Description

- Fix the windows test CI
- add Dependabot for GitHub actions

There were 2 issues:
- Vulkan 1.3.275 is no longer available for download (removed after 2 years)
- Since 2026-06-15 all `windows-2025` runners are redirected to `windows-2025-vs2026` which broke the CUDA installation, as it uses a hard-coded path for VS22.

Fixed by :
- updating the used Vulkan version to 1.4.304.1 (already used by the release action), Vulkan SDKs should be backwards compatible
- changing the runner to windows-2022 that still uses VS22

I tested a switch to VS26 [here](https://github.com/JonasTrenkler/rayx/tree/vs2026-cuda13.3), but due to the following issues this is not possible right now:
- CMAKE has issues detecting CUDA with VS2026, which was apparently fixed with CUDA 13.2.
- Alpaka currently does not support that CUDA version, support for 13.3 is planned for Alpaka 2.2

**Optional notes for reviewer:**  
- This was only tested for the `testWindows` workflow, the `release` workflow was updated accordingly and should be closer to the test now
- Switched to the lightweight `setup-vulkan-sdk` that release already used. This should only take a couple of MB instead of one huge download, but needs to be build therefore initially slower until cached in the main branch. This also simplifies the GLSL validator dependency. The smaller caches hopefully make room to cache other jobs in the future (needs to be changed in the other workflows as well)
- Dependabot could be annoying, but it's limited to for GitHub actions, should run weekly and bundle updates into one PR. Added because a lot of our used actions are deprecated currently signaling that this should be review more regularly.

----------

## ✅ Pre-Merge Checklist

> [!IMPORTANT]
> By requesting a review, you confirm this PR is complete from your side. Once approved, it may be merged by someone else. Both developers and reviewers must ensure the PR is truly ready for merge when all checks are green.

Please complete each item before requesting a review.

- [ ] Code follows the project's coding standards
- [ ] Unit tests for new functionality are added and pass
- [ ] All existing tests pass
- [ ] Resolved `TODO` Comments (prefer new issues instead)
- [ ] Documentation, if applicable, including:
    - Doxygen comments for any new rayx-core API functions
    - Helpful inline comments where needed for clarity
    - Wiki pages, e.g. updated build instructions, new Element etc.
- [ ] Commits:
    - Use clear and readable commit messages (e.g. [Conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary))
    - Squash and rebase onto `master` if individual commits don’t add value
    - Ensure linear commit history (required by `master`)
