### PR TITLE
Handle energy spread units in source generation

### DIFF
--- a/Intern/rayx-core/src/Beamline/StringConversion.h
+++ b/Intern/rayx-core/src/Beamline/StringConversion.h
@@ -39,8 +39,8 @@ const std::map<std::string, ElectronEnergyOrientation> StringToElectronEnergyOri
     {"Clockwise", ElectronEnergyOrientation::Clockwise}, {"Counterclockwise", ElectronEnergyOrientation::Counterclockwise}};
 
 // EnergySpreadUnit conversion
-const std::map<EnergySpreadUnit, std::string> EnergySpreadUnitToString = {{EnergySpreadUnit::EU_PERCENT, "Percent"}, {EnergySpreadUnit::EU_eV, "eV"}};
-const std::map<std::string, EnergySpreadUnit> StringToEnergySpreadUnit = {{"Percent", EnergySpreadUnit::EU_PERCENT}, {"eV", EnergySpreadUnit::EU_eV}};
+const std::map<EnergySpreadUnit, std::string> EnergySpreadUnitToString = {{EnergySpreadUnit::EU_eV, "eV"}, {EnergySpreadUnit::EU_PERCENT, "Percent"}};
+const std::map<std::string, EnergySpreadUnit> StringToEnergySpreadUnit = {{"eV", EnergySpreadUnit::EU_eV}, {"Percent", EnergySpreadUnit::EU_PERCENT}};
 
 // RZPType conversion
 const std::map<RZPType, std::string> RZPTypeToString = {{RZPType::Elliptical, "Elliptical"}, {RZPType::Meriodional, "Meriodional"}};

--- a/Intern/rayx-core/src/Design/DesignSource.cpp
+++ b/Intern/rayx-core/src/Design/DesignSource.cpp
@@ -184,7 +184,22 @@ void DesignSource::setEnergySpread(double value) { m_elementParameters["energySp
 double DesignSource::getEnergySpread() const { return m_elementParameters["energySpread"].as_double(); }
 
 void DesignSource::setEnergySpreadUnit(EnergySpreadUnit value) { m_elementParameters["energySpreadUnit"] = value; }
-EnergySpreadUnit DesignSource::getEnergySpreadUnit() const { return m_elementParameters["energySpreadUnit"].as_energySpreadUnit(); }
+EnergySpreadUnit DesignSource::getEnergySpreadUnit() const {
+    if (!m_elementParameters.hasKey("energySpreadUnit")) {
+        return EnergySpreadUnit::EU_eV;
+    }
+
+    return m_elementParameters["energySpreadUnit"].as_energySpreadUnit();
+}
+
+double DesignSource::getEnergySpreadInEv() const {
+    const double energySpread = getEnergySpread();
+    if (getEnergySpreadUnit() == EnergySpreadUnit::EU_PERCENT) {
+        return getEnergy() * energySpread / 100.0;
+    }
+
+    return energySpread;
+}
 
 void DesignSource::setEnergyDistributionType(EnergyDistributionType value) { m_elementParameters["energyDistributionType"] = value; }
 EnergyDistributionType DesignSource::getEnergyDistributionType() const {
@@ -217,7 +232,7 @@ EnergyDistributionVariant DesignSource::getEnergyDistribution() const {
         en              = EnergyDistributionVariant(df);
     } else if (energyDistributionType == EnergyDistributionType::Values) {
         double photonEnergy = m_elementParameters["energy"].as_double();
-        double energySpread = m_elementParameters["energySpread"].as_double();
+        double energySpread = getEnergySpreadInEv();
 
         if (spreadType == SpreadType::SoftEdge) {
             if (energySpread == 0) { energySpread = 1; }

--- a/Intern/rayx-core/src/Design/DesignSource.h
+++ b/Intern/rayx-core/src/Design/DesignSource.h
@@ -83,6 +83,7 @@ class RAYX_API DesignSource : public BeamlineNode {
 
     void setEnergySpreadUnit(EnergySpreadUnit value);
     EnergySpreadUnit getEnergySpreadUnit() const;
+    double getEnergySpreadInEv() const;
 
     void setElectronEnergy(double value);
     double getElectronEnergy() const;

--- a/Intern/rayx-core/src/Rml/DesignSourceWriter.h
+++ b/Intern/rayx-core/src/Rml/DesignSourceWriter.h
@@ -11,6 +11,17 @@
 
 namespace rayx {
 
+namespace {
+EnergySpreadUnit parseEnergySpreadUnitOrDefault(xml::Parser parser) {
+    int energySpreadUnit = 0;
+    if (!xml::paramInt(parser.node, "energySpreadUnit", &energySpreadUnit)) {
+        return EnergySpreadUnit::EU_eV;
+    }
+
+    return static_cast<EnergySpreadUnit>(energySpreadUnit);
+}
+}  // unnamed namespace
+
 void setAllMandatory(xml::Parser parser, DesignSource* ds) {
     ds->setName(parser.name());
     ds->setType(parser.type());
@@ -28,6 +39,7 @@ void setDefaultEnergy(xml::Parser parser, DesignSource* ds) {
     } else {
         ds->setEnergy(parser.parsePhotonEnergy());
         ds->setEnergySpread(parser.parseEnergySpread());
+        ds->setEnergySpreadUnit(parseEnergySpreadUnitOrDefault(parser));
         if (ds->getEnergySpreadType() == SpreadType::SeparateEnergies) ds->setNumberOfSeparateEnergies(parser.parseNumberOfSeparateEnergies());
     }
 }
@@ -84,7 +96,7 @@ void setDipoleSource(xml::Parser parser, DesignSource* ds) {
     ds->setSourceWidth(parser.parseSourceWidth());
     ds->setVerEBeamDivergence(parser.parseVerEbeamDivergence());
     ds->setEnergy(parser.parsePhotonEnergy());
-    ds->setEnergySpreadUnit(parser.parseEnergySpreadUnit());
+    ds->setEnergySpreadUnit(parseEnergySpreadUnitOrDefault(parser));
     ds->setEnergyDistributionType(parser.parseEnergyDistributionType());
     ds->setHorDivergence(parser.parseHorDiv());
 }

--- a/Intern/rayx-core/src/Rml/xml.h
+++ b/Intern/rayx-core/src/Rml/xml.h
@@ -175,7 +175,6 @@ struct RAYX_API Parser {
     inline EnergyDistributionType parseEnergyDistributionType() const {
         return static_cast<EnergyDistributionType>(parseInt("energyDistributionType"));
     }
-    inline EnergySpreadUnit parseEnergySpreadUnit() const { return static_cast<EnergySpreadUnit>(parseInt("energySpreadUnit")); }
     inline int parseNumberOfSeparateEnergies() const { return parseInt("SeparateEnergies"); }
     inline int parseNumOfEquidistantCircles() const { return static_cast<int>(parseDouble("numberCircles")); }
     inline Rad parseMaxOpeningAngle() const { return parseDouble("maximumOpeningAngle") / 1000.0; }

--- a/Intern/rayx-core/src/Shader/LightSources/DipoleSource.cpp
+++ b/Intern/rayx-core/src/Shader/LightSources/DipoleSource.cpp
@@ -374,7 +374,7 @@ DipoleSource::DipoleSource(const DesignSource& dSource)
       m_verEbeamDivergence(dSource.getVerEBeamDivergence()),
       // m_bandwidth(1.0e-3),
       // m_photonWaveLength(hvlam(m_photonEnergy)),
-      m_energySpread(dSource.getEnergySpread()),
+      m_energySpread(dSource.getEnergySpreadInEv()),
       m_horDivergence(dSource.getHorDivergence()) {
     auto rand       = Rand(randomUint());
     m_gamma         = calcGamma(m_electronEnergy);

--- a/Intern/rayx-core/src/Shader/LightSources/LightSource.h
+++ b/Intern/rayx-core/src/Shader/LightSources/LightSource.h
@@ -15,7 +15,7 @@ namespace rayx {
 
 enum class SourceDist { Uniform, Gaussian, Thirds, Circle };  // SourceDist::Thirds represents PixelSource Footprint
 enum class ElectronEnergyOrientation { Clockwise, Counterclockwise };
-enum class EnergySpreadUnit { EU_PERCENT, EU_eV };
+enum class EnergySpreadUnit { EU_eV, EU_PERCENT };
 enum class SigmaType { ST_STANDARD, ST_ACCURATE };
 enum class SourcePulseType { None };
 

--- a/Intern/rayx-core/tests/input/PointSourceHardEdgePercent.rml
+++ b/Intern/rayx-core/tests/input/PointSourceHardEdgePercent.rml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<lab>
+<version>1.12</version>
+<beamline>
+
+  <object name="Point Source" type="Point Source">
+    <param id="numberRays" enabled="T">200</param>
+    <param id="sourceWidthDistribution" comment="hard edge" enabled="T">0</param>
+    <param id="sourceWidth" enabled="T">0.065</param>
+    <param id="sourceHeightDistribution" comment="gaussian (sigma)" enabled="T">1</param>
+    <param id="sourceHeight" enabled="T">0.04</param>
+    <param id="sourceDepth" enabled="T">1</param>
+    <param id="horDivDistribution" comment="gaussian (sigma)" enabled="T">1</param>
+    <param id="horDiv" enabled="T">1</param>
+    <param id="verDivDistribution" comment="gaussian (sigma)" enabled="T">1</param>
+    <param id="verDiv" enabled="T">1</param>
+    <param id="alignmentError" comment="No" enabled="T">1</param>
+    <param id="translationXerror" enabled="F">0</param>
+    <param id="translationYerror" enabled="F">0</param>
+    <param id="rotationXerror" enabled="F">0</param>
+    <param id="rotationYerror" enabled="F">0</param>
+    <param id="energyDistributionType" comment="Values" enabled="T">1</param>
+    <param id="photonEnergyDistributionFile" absolute="" enabled="F"></param>
+    <param id="photonEnergy" enabled="T">100</param>
+    <param id="energySpreadType" comment="white band" enabled="T">0</param>
+    <param id="energySpreadUnit" comment="%" enabled="T">1</param>
+    <param id="energySpread" enabled="T">10</param>
+    <param id="linearPol_0" enabled="T">1</param>
+    <param id="linearPol_45" enabled="T">0</param>
+    <param id="circularPol" enabled="T">0</param>
+    <param id="sourcePulseType" comment="all rays start simultaneously" enabled="T">0</param>
+    <param id="sourcePulseLength" enabled="F">0</param>
+    <param id="worldPosition" enabled="F">
+      <x>0</x>
+      <y>0</y>
+      <z>0</z>
+    </param>
+    <param id="worldXdirection" enabled="F">
+      <x>1</x>
+      <y>0</y>
+      <z>0</z>
+    </param>
+    <param id="worldYdirection" enabled="F">
+      <x>0</x>
+      <y>1</y>
+      <z>0</z>
+    </param>
+    <param id="worldZdirection" enabled="F">
+      <x>0</x>
+      <y>0</y>
+      <z>1</z>
+    </param>
+  </object>
+
+</beamline>
+
+<ExtraData>
+</ExtraData>
+</lab>

--- a/Intern/rayx-core/tests/input/dipole_energySpread_percent.rml
+++ b/Intern/rayx-core/tests/input/dipole_energySpread_percent.rml
@@ -1,0 +1,50 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<lab>
+ <version>1.13</version>
+ <beamline>
+  <object name="Dipole Source" type="Dipole Source">
+   <param id="numberRays" enabled="T">200</param>
+   <param id="sourceWidth" enabled="T">0.065</param>
+   <param id="sourceHeight" enabled="T">0.04</param>
+   <param id="verEbeamDiv" enabled="T">1</param>
+   <param id="horDiv" enabled="T">100</param>
+   <param id="electronEnergy" enabled="T">1.7</param>
+   <param id="electronEnergyOrientation" comment="clockwise" enabled="T">0</param>
+   <param id="bendingRadius" enabled="T">4.35</param>
+   <param id="alignmentError" comment="No" enabled="T">1</param>
+   <param id="translationXerror" enabled="F">0</param>
+   <param id="translationYerror" enabled="F">0</param>
+   <param id="rotationXerror" enabled="F">0</param>
+   <param id="rotationYerror" enabled="F">0</param>
+   <param id="worldPosition" enabled="F">
+    <x>0.0000000000000000</x>
+    <y>0.0000000000000000</y>
+    <z>0.0000000000000000</z>
+   </param>
+   <param id="worldXdirection" enabled="F">
+    <x>1.0000000000000000</x>
+    <y>0.0000000000000000</y>
+    <z>0.0000000000000000</z>
+   </param>
+   <param id="worldYdirection" enabled="F">
+    <x>0.0000000000000000</x>
+    <y>1.0000000000000000</y>
+    <z>0.0000000000000000</z>
+   </param>
+   <param id="worldZdirection" enabled="F">
+    <x>0.0000000000000000</x>
+    <y>0.0000000000000000</y>
+    <z>1.0000000000000000</z>
+   </param>
+   <param id="energyDistributionType" comment="Values" enabled="T">1</param>
+   <param id="photonEnergyDistributionFile" absolute="" enabled="F"></param>
+   <param id="photonEnergy" enabled="T">1000</param>
+   <param id="energySpreadType" comment="white band" enabled="T">0</param>
+   <param id="energySpreadUnit" comment="%" enabled="T">1</param>
+   <param id="energySpread" enabled="T">10</param>
+   <param id="sourcePulseType" comment="all rays start simultaneously" enabled="T">0</param>
+   <param id="sourcePulseLength" enabled="F">0</param>
+   <param id="photonFlux" enabled="T">2.76089e+12</param>
+  </object>
+ </beamline>
+</lab>

--- a/Intern/rayx-core/tests/testSources.cpp
+++ b/Intern/rayx-core/tests/testSources.cpp
@@ -8,6 +8,11 @@ void checkEnergyDistribution(const Rays& rays, double photonEnergy, double energ
     for (const auto energy : rays.energy) { CHECK_IN(energy, photonEnergy - energySpread, photonEnergy + energySpread); }
 }
 
+void checkEnergyDistributionWindow(const Rays& rays, double minEnergy, double maxEnergy) {
+    CHECK(rays.energy.size() > 0);
+    for (const auto energy : rays.energy) { CHECK_IN(energy, minEnergy, maxEnergy); }
+}
+
 void checkZDistribution(const Rays& rays, double center, double spread) {
     CHECK(rays.position_z.size() > 0);
     for (const auto position_z : rays.position_z) { CHECK_IN(position_z, center - spread, center + spread); }
@@ -51,6 +56,10 @@ TEST_F(TestSuite, MatrixSourceTracedRayUI) {
 
 TEST_F(TestSuite, PointSourceHardEdge) { checkEnergyDistribution(traceRml("PointSourceHardEdge", RayAttrMask::Energy), 120.97, 12.1); }
 
+TEST_F(TestSuite, PointSourceHardEdgePercentUnit) {
+    checkEnergyDistributionWindow(traceRml("PointSourceHardEdgePercent", RayAttrMask::Energy), 95.0, 105.0);
+}
+
 TEST_F(TestSuite, PointSourceSoftEdge) { checkEnergyDistribution(traceRml("PointSourceSoftEdge", RayAttrMask::Energy), 151, 6); }
 
 TEST_F(TestSuite, MatrixSourceEnergyDistribution) { checkEnergyDistribution(traceRml("PointSourceSoftEdge", RayAttrMask::Energy), 151, 6); }
@@ -60,6 +69,10 @@ TEST_F(TestSuite, DipoleSourcePosition) {
 }
 
 TEST_F(TestSuite, DipoleEnergyDistribution) { checkEnergyDistribution(traceRml("dipole_energySpread", RayAttrMask::Energy), 1000, 23000); }
+
+TEST_F(TestSuite, DipoleEnergyDistributionPercentUnit) {
+    checkEnergyDistributionWindow(traceRml("dipole_energySpread_percent", RayAttrMask::Energy), 950.0, 1050.0);
+}
 
 TEST_F(TestSuite, PixelPositionTest) {
     const auto [beamline, rays] =


### PR DESCRIPTION
## Type of Change

- [x] Bug fix (non breaking change, fixing an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Documentation / Wiki update

## Description

Correct parsing of the energy spread unit. It was not implemented before but the behavior for users is very confusing so I'll classify this as a bugfix.

Fixed #470 

**Optional notes for reviewer:**  
-

----------

## ✅ Pre-Merge Checklist

> [!IMPORTANT]
> By requesting a review, you confirm this PR is complete from your side. Once approved, it may be merged by someone else. Both developers and reviewers must ensure the PR is truly ready for merge when all checks are green.

Please complete each item before requesting a review.

- [ ] Code follows the project's coding standards
- [x] Unit tests for new functionality are added and pass
- [x] All existing tests pass
- [x] Resolved `TODO` Comments (prefer new issues instead)
- [x] Documentation, if applicable, including:
    - Doxygen comments for any new rayx-core API functions
    - Helpful inline comments where needed for clarity
    - Wiki pages, e.g. updated build instructions, new Element etc.
- [x] Commits:
    - Use clear and readable commit messages (e.g. [Conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary))
    - Squash and rebase onto `master` if individual commits don’t add value
    - Ensure linear commit history (required by `master`)
